### PR TITLE
refactor(nav): remove isNotHome prop from navigation components

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -79,7 +79,7 @@ export default async function Page({
 
   return (
     <>
-      <HeaderMotion isNotHome />
+      <HeaderMotion />
 
       <div className="max-w-screen overflow-x-hidden">
         <div className="mx-auto px-4 md:max-w-3xl">
@@ -87,14 +87,14 @@ export default async function Page({
             <div className="mb-8 flex justify-end">
               <div className="ring-grid relative -top-px -right-px z-1 flex items-center gap-2 ring ring-inset">
                 <div className="hidden sm:block">
-                  <NavDesktop isNotHome />
+                  <NavDesktop />
                 </div>
 
                 <NavGitHub />
                 <ToggleTheme />
 
                 <div className="sm:hidden">
-                  <NavMobile isNotHome />
+                  <NavMobile />
                 </div>
               </div>
             </div>

--- a/src/features/profile/components/header-motion.tsx
+++ b/src/features/profile/components/header-motion.tsx
@@ -11,7 +11,7 @@ import { NavDesktop } from "./nav/nav-desktop";
 import { NavGitHub } from "./nav/nav-github";
 import { NavMobile } from "./nav/nav-mobile";
 
-export function HeaderMotion({ isNotHome }: { isNotHome?: boolean }) {
+export function HeaderMotion() {
   const { scrollY } = useScroll();
 
   const _top = useTransform(scrollY, [100, 400], [-80, 0]);
@@ -43,17 +43,14 @@ export function HeaderMotion({ isNotHome }: { isNotHome?: boolean }) {
 
             <div className="-mr-px flex items-center gap-2">
               <div className="hidden sm:block">
-                <NavDesktop
-                  className="rounded-none border-0 px-1"
-                  isNotHome={isNotHome}
-                />
+                <NavDesktop className="rounded-none border-0 px-1" />
               </div>
 
               <NavGitHub />
               <ToggleTheme />
 
               <div className="sm:hidden">
-                <NavMobile isNotHome={isNotHome} />
+                <NavMobile />
               </div>
             </div>
           </div>

--- a/src/features/profile/components/header.tsx
+++ b/src/features/profile/components/header.tsx
@@ -16,7 +16,7 @@ export function Header() {
       <ChanhDaiCoverGrid />
 
       <div className="border-grid ring-grid bg-background absolute -top-px right-0 flex items-center gap-2 ring ring-inset">
-        <div className="hidden sm:block">
+        <div className="hidden pr-1 pl-3 sm:block">
           <NavDesktop />
         </div>
 

--- a/src/features/profile/components/nav/nav-desktop.tsx
+++ b/src/features/profile/components/nav/nav-desktop.tsx
@@ -5,27 +5,16 @@ import { cn } from "@/lib/cn";
 
 import { NavLink } from "./nav-link";
 
-export function NavDesktop({
-  className,
-  isNotHome,
-}: {
-  className?: string;
-  isNotHome?: boolean;
-}) {
+export function NavDesktop({ className }: { className?: string }) {
   return (
     <nav
       className={cn(
-        "bg-background text-foreground flex h-8 items-center gap-3 rounded-full border px-3 font-mono text-sm *:underline-offset-4 *:hover:underline",
+        "text-foreground flex h-8 items-center gap-3 rounded-full font-mono text-sm *:underline-offset-4 *:hover:underline",
         className
       )}
     >
       {NAV_LINKS.map((link) => (
-        <NavLink
-          key={link.href}
-          href={link.href}
-          title={link.title}
-          isNotHome={isNotHome}
-        />
+        <NavLink key={link.href} href={link.href} title={link.title} />
       ))}
     </nav>
   );

--- a/src/features/profile/components/nav/nav-link.tsx
+++ b/src/features/profile/components/nav/nav-link.tsx
@@ -1,17 +1,23 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import React from "react";
 
 export function NavLink({
   href,
   title,
-  isNotHome,
+
   ...props
-}: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+}: React.ComponentProps<"a"> & {
   href: string;
   title: string;
-  isNotHome?: boolean;
 }) {
-  const shouldUseNextLink = isNotHome;
-  const newHref = shouldUseNextLink ? `/${href}` : href;
+  const pathname = usePathname();
+  const isHome = pathname === "/";
+
+  const newHref = href.startsWith("#") && !isHome ? `/${href}` : href;
+  const shouldUseNextLink = newHref.startsWith("/");
 
   if (shouldUseNextLink) {
     return (

--- a/src/features/profile/components/nav/nav-mobile.tsx
+++ b/src/features/profile/components/nav/nav-mobile.tsx
@@ -13,7 +13,7 @@ import { NAV_LINKS } from "@/config/site";
 
 import { NavLink } from "./nav-link";
 
-export function NavMobile({ isNotHome }: { isNotHome?: boolean }) {
+export function NavMobile() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -39,11 +39,7 @@ export function NavMobile({ isNotHome }: { isNotHome?: boolean }) {
             className="font-mono text-sm"
             asChild
           >
-            <NavLink
-              title={link.title}
-              href={link.href}
-              isNotHome={isNotHome}
-            />
+            <NavLink title={link.title} href={link.href} />
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>


### PR DESCRIPTION
Remove the isNotHome prop from HeaderMotion, NavDesktop, NavMobile, and NavLink components to simplify the navigation logic. Determine the home page status using usePathname hook in NavLink to conditionally adjust href for hash links. This change reduces complexity and improves maintainability by centralizing the logic for determining link behavior.