### PR TITLE
style(components): update styles for light mode compatibility

### DIFF
--- a/src/components/code-block-command.tsx
+++ b/src/components/code-block-command.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PackageManager, useConfig } from "@/hooks/use-config";
+import { cn } from "@/lib/cn";
 import { NpmCommands } from "@/types/unist";
 
 import { CopyButton } from "./copy-button";
@@ -28,7 +29,7 @@ export function CodeBlockCommand({
   }, [__pnpmCommand__, __yarnCommand__, __npmCommand__, __bunCommand__]);
 
   return (
-    <div className="relative overflow-hidden rounded-lg bg-zinc-950 dark:bg-zinc-900">
+    <div className="relative not-dark:overflow-hidden not-dark:rounded-lg not-dark:bg-zinc-950">
       <Tabs
         className="gap-0"
         value={packageManager}
@@ -39,7 +40,7 @@ export function CodeBlockCommand({
           }));
         }}
       >
-        <div className="border-b border-zinc-800 px-4">
+        <div className="border-b border-zinc-800 px-4 dark:bg-zinc-900/50">
           <TabsList className="h-auto translate-y-px gap-3 rounded-none bg-transparent p-0 dark:bg-transparent">
             {Object.entries(tabs).map(([key]) => {
               return (
@@ -75,6 +76,22 @@ export function CodeBlockCommand({
       <CopyButton
         className="absolute top-2 right-2"
         value={tabs[packageManager] || ""}
+      />
+
+      <span
+        className={cn(
+          "not-dark:hidden",
+          "before:absolute before:-inset-x-2 before:top-0 before:h-px before:bg-border",
+          "after:absolute after:-inset-x-2 after:bottom-0 after:h-px after:bg-border"
+        )}
+      />
+
+      <span
+        className={cn(
+          "not-dark:hidden",
+          "before:absolute before:-inset-y-2 before:left-0 before:w-px before:bg-border",
+          "after:absolute after:-inset-y-2 after:right-0 after:w-px after:bg-border"
+        )}
       />
     </div>
   );

--- a/src/components/component-preview.tsx
+++ b/src/components/component-preview.tsx
@@ -44,7 +44,7 @@ export function ComponentPreview({
           <TabsTrigger value="code">Code</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="preview" className="rounded-lg border">
+        <TabsContent value="preview" className="relative">
           <div
             className={cn(
               "flex min-h-[320px] items-center justify-center p-4",
@@ -61,6 +61,20 @@ export function ComponentPreview({
               {Preview}
             </React.Suspense>
           </div>
+
+          <span
+            className={cn(
+              "before:absolute before:-inset-x-2 before:top-0 before:h-px before:bg-border",
+              "after:absolute after:-inset-x-2 after:bottom-0 after:h-px after:bg-border"
+            )}
+          />
+
+          <span
+            className={cn(
+              "before:absolute before:-inset-y-2 before:left-0 before:w-px before:bg-border",
+              "after:absolute after:-inset-y-2 after:right-0 after:w-px after:bg-border"
+            )}
+          />
         </TabsContent>
 
         <TabsContent value="code" className="[&>figure]:m-0">

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -84,6 +84,25 @@ const components: MDXRemoteProps["components"] = {
             value={__rawString__}
           />
         )}
+
+        <span
+          className={cn(
+            "not-dark:hidden",
+            "before:absolute before:-inset-x-2 before:top-0 before:h-px before:bg-border",
+            __withMeta__ && "before:top-7",
+            "after:absolute after:-inset-x-2 after:bottom-0 after:h-px after:bg-border"
+          )}
+        />
+
+        <span
+          className={cn(
+            "not-dark:hidden",
+            "before:absolute before:-inset-y-2 before:left-0 before:w-px before:bg-border",
+            __withMeta__ && "before:top-5",
+            "after:absolute after:-inset-y-2 after:right-0 after:w-px after:bg-border",
+            __withMeta__ && "after:top-5"
+          )}
+        />
       </>
     );
   },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -182,7 +182,7 @@
   @apply my-6;
 
   pre {
-    @apply max-h-[512px] overflow-x-auto rounded-lg bg-zinc-950 py-4 dark:bg-zinc-900;
+    @apply max-h-[512px] overflow-x-auto bg-zinc-950 py-4 not-dark:rounded-lg dark:bg-zinc-900/50;
   }
 
   code {


### PR DESCRIPTION
Add conditional styles to support light mode by using 'not-dark' prefix. Ensure consistent border rendering across components by adding spans with before and after pseudo-elements. Adjust component styles to maintain visual integrity in both light and dark modes.