### PR TITLE
feat(certification-item.tsx): add link to certification credential URL

### DIFF
--- a/src/features/profile/components/certifications/certification-item.tsx
+++ b/src/features/profile/components/certifications/certification-item.tsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { CheckCircleIcon } from "lucide-react";
+import { ArrowUpRightIcon, CheckCircleIcon } from "lucide-react";
 import Image from "next/image";
 import React from "react";
 
@@ -15,7 +15,12 @@ export function CertificationItem({
   certification: Certification;
 }) {
   return (
-    <div className={cn("flex items-center", className)}>
+    <a
+      className={cn("group/cert flex items-center pr-2", className)}
+      href={certification.credentialURL}
+      target="_blank"
+      rel="noopener"
+    >
       {certification.issuerLogo ? (
         <Image
           src={certification.issuerLogo}
@@ -34,8 +39,8 @@ export function CertificationItem({
         </div>
       )}
 
-      <div className="space-y-1 border-l border-dashed border-grid px-2 py-4">
-        <h3 className="font-heading text-lg leading-snug font-medium text-balance">
+      <div className="flex-1 space-y-1 border-l border-dashed border-grid px-2 py-4">
+        <h3 className="font-heading text-lg leading-snug font-medium text-balance decoration-ring underline-offset-4 group-hover/cert:underline">
           {certification.title}
         </h3>
 
@@ -48,6 +53,10 @@ export function CertificationItem({
           <span>{dayjs(certification.issueDate).format("DD.MM.YYYY")}</span>
         </p>
       </div>
-    </div>
+
+      {certification.credentialURL && (
+        <ArrowUpRightIcon className="size-4 text-muted-foreground" />
+      )}
+    </a>
   );
 }

--- a/src/features/profile/components/projects/project-item.tsx
+++ b/src/features/profile/components/projects/project-item.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, CodeXmlIcon, ExternalLink } from "lucide-react";
+import { ArrowUpRightIcon, ChevronDownIcon, CodeXmlIcon } from "lucide-react";
 import Image from "next/image";
 import { Accordion as AccordionPrimitive } from "radix-ui";
 import React from "react";
@@ -46,12 +46,12 @@ export function ProjectItem({
               <h3 className="mb-1 flex items-center gap-1 font-heading text-lg leading-snug font-medium text-balance decoration-ring underline-offset-4 group-hover/project:underline">
                 {project.title}
                 <a
-                  className="flex size-6 shrink-0 -translate-y-px items-center justify-center text-muted-foreground"
+                  className="flex size-6 shrink-0 items-center justify-center text-muted-foreground"
                   href={addQueryParams(project.link, UTM_PARAMS)}
                   target="_blank"
                   rel="noopener"
                 >
-                  <ExternalLink className="pointer-events-none size-4" />
+                  <ArrowUpRightIcon className="pointer-events-none size-4" />
                   <span className="sr-only">Open</span>
                 </a>
               </h3>

--- a/src/features/profile/components/social-links/social-link-item.tsx
+++ b/src/features/profile/components/social-links/social-link-item.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon } from "lucide-react";
+import { ArrowUpRightIcon } from "lucide-react";
 import Image from "next/image";
 
 import { SocialLink } from "@/features/profile/types/social-links";
@@ -40,7 +40,7 @@ export function SocialLinkItem({ icon, title, description, href }: SocialLink) {
         )}
       </div>
 
-      <ExternalLinkIcon className="size-4 text-muted-foreground" />
+      <ArrowUpRightIcon className="size-4 text-muted-foreground" />
     </a>
   );
 }

--- a/src/features/profile/data/certifications.ts
+++ b/src/features/profile/data/certifications.ts
@@ -62,6 +62,7 @@ export const CERTIFICATIONS: Certification[] = [
     title: "Digital Skills: Social Media",
     issuer: "Accenture",
     issueDate: "2022-08-27",
+    credentialID: "pc4345i",
     credentialURL: "https://www.futurelearn.com/certificates/pc4345i",
   },
   {

--- a/src/features/profile/types/certifications.ts
+++ b/src/features/profile/types/certifications.ts
@@ -3,6 +3,6 @@ export type Certification = {
   issuer: string;
   issuerLogo?: string;
   issueDate: string;
-  credentialID?: string;
-  credentialURL?: string;
+  credentialID: string;
+  credentialURL: string;
 };


### PR DESCRIPTION
Use an anchor tag to wrap the certification item, allowing users to click and open the certification credential URL in a new tab. Add underline effect on hover for better user experience. Include an ArrowUpRightIcon to indicate external link.

refactor: replace ExternalLinkIcon with ArrowUpRightIcon

Standardize the icon used for external links across components by replacing ExternalLinkIcon with ArrowUpRightIcon in project-item.tsx and social-link-item.tsx for consistency.

fix(certifications.ts): make credentialID and credentialURL required

Ensure that credentialID and credentialURL are mandatory fields in Certification type to maintain data integrity and prevent potential runtime errors.