### PR TITLE
feat(awards, projects): change accordion type to multiple for better UX

### DIFF
--- a/src/features/profile/components/awards/index.tsx
+++ b/src/features/profile/components/awards/index.tsx
@@ -23,7 +23,7 @@ export function Awards() {
         </PanelTitle>
       </PanelHeader>
 
-      <AccordionPrimitive.Root type="single" collapsible>
+      <AccordionPrimitive.Root type="multiple">
         <CollapsibleList
           items={SORTED_AWARDS}
           max={3}

--- a/src/features/profile/components/projects/index.tsx
+++ b/src/features/profile/components/projects/index.tsx
@@ -19,9 +19,8 @@ export function Projects() {
       </PanelHeader>
 
       <AccordionPrimitive.Root
-        type="single"
-        defaultValue="portfolio-website"
-        collapsible
+        type="multiple"
+        defaultValue={["portfolio-website", "zadark"]}
       >
         <CollapsibleList
           items={PROJECTS}


### PR DESCRIPTION
Change accordion type from single to multiple in both awards and projects components to allow users to expand multiple sections simultaneously. Adjust defaultValue in projects to open multiple sections by default.