### PR TITLE
perf(images): add 'unoptimized' attribute to all image components

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -189,6 +189,7 @@ export function CommandMenu() {
                   width={20}
                   height={20}
                   alt={item.title}
+                  unoptimized
                 />
                 {item.title}
               </CommandItem>

--- a/src/components/post-item.tsx
+++ b/src/components/post-item.tsx
@@ -31,6 +31,7 @@ export function PostItem({
             height={630}
             quality={100}
             priority={shouldPreloadImage}
+            unoptimized
           />
 
           <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-black/10 ring-inset dark:ring-white/10" />

--- a/src/features/profile/components/certifications/certification-item.tsx
+++ b/src/features/profile/components/certifications/certification-item.tsx
@@ -29,6 +29,7 @@ export function CertificationItem({
           height={32}
           quality={100}
           className="mx-4 flex size-6 shrink-0"
+          unoptimized
         />
       ) : (
         <div

--- a/src/features/profile/components/experiences/experience-item.tsx
+++ b/src/features/profile/components/experiences/experience-item.tsx
@@ -17,6 +17,7 @@ export function ExperienceItem({ experience }: { experience: Experience }) {
               height={24}
               quality={100}
               className="rounded-full"
+              unoptimized
             />
           ) : (
             <span className="flex size-2 rounded-full bg-zinc-300 dark:bg-zinc-600" />

--- a/src/features/profile/components/header.tsx
+++ b/src/features/profile/components/header.tsx
@@ -25,6 +25,7 @@ export function Header() {
               height={512}
               quality={100}
               priority
+              unoptimized
             />
           </div>
           {/* Flag of Viet Nam */}

--- a/src/features/profile/components/projects/project-item.tsx
+++ b/src/features/profile/components/projects/project-item.tsx
@@ -30,6 +30,7 @@ export function ProjectItem({
             height={32}
             quality={100}
             className="mx-4 flex size-6 shrink-0"
+            unoptimized
           />
         ) : (
           <div

--- a/src/features/profile/components/social-links/social-link-item.tsx
+++ b/src/features/profile/components/social-links/social-link-item.tsx
@@ -24,6 +24,7 @@ export function SocialLinkItem({ icon, title, description, href }: SocialLink) {
           width={48}
           height={48}
           quality={100}
+          unoptimized
         />
         <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-black/8 ring-inset dark:ring-white/8" />
       </div>

--- a/src/features/profile/components/teck-stack.tsx
+++ b/src/features/profile/components/teck-stack.tsx
@@ -39,6 +39,7 @@ export function TeckStack() {
                         width={32}
                         height={32}
                         className="hidden [html.light_&]:block"
+                        unoptimized
                       />
                       <Image
                         src={`https://assets.chanhdai.com/images/tech-stack-icons/${item.key}-dark.svg`}
@@ -46,6 +47,7 @@ export function TeckStack() {
                         width={32}
                         height={32}
                         className="hidden [html.dark_&]:block"
+                        unoptimized
                       />
                     </>
                   ) : (
@@ -54,6 +56,7 @@ export function TeckStack() {
                       alt={`${item.title} icon`}
                       width={32}
                       height={32}
+                      unoptimized
                     />
                   )}
                 </a>


### PR DESCRIPTION
Add 'unoptimized' attribute to improve performance by bypassing default image optimization. This change is necessary for scenarios where external image optimization is preferred or when optimization is not needed, reducing processing overhead.