### PR TITLE
style(command.tsx): remove redundant backdrop styling from Command co…

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -20,7 +20,7 @@ function Command({
     <CommandPrimitive
       data-slot="command"
       className={cn(
-        "flex h-full w-full flex-col overflow-hidden bg-popover text-popover-foreground backdrop-blur-md supports-[backdrop-filter]:bg-popover/90",
+        "flex h-full w-full flex-col overflow-hidden text-popover-foreground",
         className
       )}
       {...props}
@@ -44,7 +44,12 @@ function CommandDialog({
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
 
-      <DialogContent className="top-16 translate-y-0 overflow-hidden bg-transparent p-0 sm:top-[20vh]">
+      <DialogContent
+        className={cn(
+          "top-16 translate-y-0 overflow-hidden p-0 sm:top-[20vh]",
+          "bg-popover backdrop-blur-md supports-[backdrop-filter]:bg-popover/90"
+        )}
+      >
         <Command
           className={cn(
             "**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-10",
@@ -72,14 +77,15 @@ function CommandInput({
       <svg
         className="size-4 shrink-0 opacity-50"
         xmlns="http://www.w3.org/2000/svg"
+        fill="none"
         viewBox="0 0 16 16"
         aria-hidden
       >
         <path
-          d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z"
+          d="M10.278 11.514a5.824 5.824 0 1 1 1.235-1.235l3.209 3.208A.875.875 0 0 1 14.111 15a.875.875 0 0 1-.624-.278l-3.209-3.208Zm.623-4.69a4.077 4.077 0 1 1-8.154 0 4.077 4.077 0 0 1 8.154 0Z"
+          fill="currentColor"
           fillRule="evenodd"
           clipRule="evenodd"
-          fill="currentColor"
         />
       </svg>
 


### PR DESCRIPTION
…mponent for cleaner code

style(command.tsx): move backdrop styling to DialogContent for better separation of concerns
fix(command.tsx): update SVG path for CommandInput to correct icon rendering
style(command.tsx): add 'fill="none"' to SVG for improved styling control