### PR TITLE
feat(api): add new route to fetch GitHub stargazers count

### DIFF
--- a/src/app/api/stargazers_count/route.ts
+++ b/src/app/api/stargazers_count/route.ts
@@ -1,0 +1,14 @@
+export async function GET() {
+  const data = await fetch("https://api.github.com/repos/ncdai/chanhdai.com", {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${process.env.GITHUB_API_TOKEN}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    next: { revalidate: 86400 }, // Cache for 1 day (86400 seconds)
+  });
+  const json = await data.json();
+  return Response.json({
+    stargazers_count: json?.stargazers_count ?? -1,
+  });
+}

--- a/src/components/stars-count.tsx
+++ b/src/components/stars-count.tsx
@@ -3,20 +3,20 @@
 import React from "react";
 import useSWR from "swr";
 
-const fetcher = (url: string) =>
-  fetch(url, { next: { revalidate: 86400 } }).then((r) => r.json()); // Cache for 1 day (86400 seconds)
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
 type StarsCountResponse = {
   stargazers_count: number;
 };
 
 export function StarsCount() {
-  const { data } = useSWR<StarsCountResponse>(
-    `https://api.github.com/repos/ncdai/chanhdai.com`,
-    fetcher
-  );
+  const { data } = useSWR<StarsCountResponse>(`/api/stargazers_count`, fetcher);
 
   if (!data) {
+    return <span className="h-3 w-7 rounded-full bg-muted" />;
+  }
+
+  if (data.stargazers_count < 0) {
     return <span className="h-3 w-7 rounded-full bg-muted" />;
   }
 


### PR DESCRIPTION
Introduce a new API route to fetch the stargazers count from GitHub for the repository 'ncdai/chanhdai.com'. This allows the application to retrieve and display the number of stars the repository has, enhancing user engagement by showing repository popularity.

refactor(stars-count.tsx): update fetch URL to use new API route

Modify the StarsCount component to use the new API route '/api/stargazers_count' instead of directly calling the GitHub API. This change abstracts the data fetching logic and centralizes API calls, improving maintainability.

fix(stars-count.tsx): handle negative stargazers count

Add a check for negative stargazers count in the StarsCount component to handle potential errors gracefully. This ensures the UI does not break if the API returns an unexpected value.