### PR TITLE
feat(mdx): add rehype-slug for automatic heading id generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "puppeteer-core": "^24.8.2",
     "rehype-external-links": "^3.0.0",
     "rehype-pretty-code": "^0.14.0",
+    "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "rimraf": "^6.0.1",
     "shiki": "1.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       rehype-pretty-code:
         specifier: ^0.14.0
         version: 0.14.0(shiki@1.9.1)
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2755,6 +2758,9 @@ packages:
     resolution: {integrity: sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==}
     engines: {node: '>= 14'}
 
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -2830,6 +2836,9 @@ packages:
 
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
 
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
@@ -4065,6 +4074,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -7518,6 +7530,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  github-slugger@2.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -7600,6 +7614,10 @@ snapshots:
       vfile: 6.0.3
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
+
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hast-util-is-element@3.0.0:
     dependencies:
@@ -9206,6 +9224,14 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.0.0
 
   remark-gfm@4.0.1:
     dependencies:

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -3,6 +3,7 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import rehypeExternalLinks from "rehype-external-links";
 import type { LineElement } from "rehype-pretty-code";
 import rehypePrettyCode from "rehype-pretty-code";
+import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import { visit } from "unist-util-visit";
 
@@ -17,7 +18,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Code } from "@/components/ui/typography";
+import { Code, Heading } from "@/components/ui/typography";
 import { UTM_PARAMS } from "@/config/site";
 import { cn } from "@/lib/cn";
 import { rehypeAddQueryParams } from "@/lib/rehype-add-query-params";
@@ -32,6 +33,12 @@ import { CopyButton } from "./copy-button";
 import { getIconForLanguageExtension } from "./icons";
 
 const components: MDXRemoteProps["components"] = {
+  h1: (props: React.ComponentProps<"h1">) => <Heading as="h1" {...props} />,
+  h2: (props: React.ComponentProps<"h2">) => <Heading as="h2" {...props} />,
+  h3: (props: React.ComponentProps<"h3">) => <Heading as="h3" {...props} />,
+  h4: (props: React.ComponentProps<"h4">) => <Heading as="h4" {...props} />,
+  h5: (props: React.ComponentProps<"h5">) => <Heading as="h5" {...props} />,
+  h6: (props: React.ComponentProps<"h6">) => <Heading as="h6" {...props} />,
   table: Table,
   thead: TableHeader,
   tbody: TableBody,
@@ -43,10 +50,7 @@ const components: MDXRemoteProps["components"] = {
 
     return (
       <figure
-        className={cn(
-          hasPrettyCode && "not-prose relative rehype-pretty-code",
-          className
-        )}
+        className={cn(hasPrettyCode && "not-prose", className)}
         {...props}
       />
     );
@@ -142,6 +146,7 @@ const options: MDXRemoteProps["options"] = {
         rehypeExternalLinks,
         { target: "_blank", rel: "nofollow noopener noreferrer" },
       ],
+      rehypeSlug,
       rehypeComponent,
       () => (tree) => {
         visit(tree, (node) => {

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -1,3 +1,4 @@
+import { LinkIcon } from "lucide-react";
 import { Slot as SlotPrimitive } from "radix-ui";
 import React from "react";
 
@@ -48,4 +49,37 @@ function Code({ className, ...props }: React.ComponentProps<"code">) {
   );
 }
 
-export { Code, Prose };
+type HeadingTypes = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+type HeadingProps<T extends HeadingTypes> = React.ComponentProps<T> & {
+  as?: T;
+};
+
+function Heading<T extends HeadingTypes = "h1">({
+  as,
+  className,
+  ...props
+}: HeadingProps<T>): React.ReactElement {
+  const Comp = as ?? "h1";
+
+  if (!props.id) {
+    return <Comp className={className} {...props} />;
+  }
+
+  return (
+    <Comp
+      className={cn("flex flex-row items-center gap-2", className)}
+      {...props}
+    >
+      <a href={`#${props.id}`} className="peer not-prose">
+        {props.children}
+      </a>
+
+      <LinkIcon
+        className="size-4 shrink-0 text-muted-foreground opacity-0 transition-opacity peer-hover:opacity-100"
+        aria-label="Link to section"
+      />
+    </Comp>
+  );
+}
+
+export { Code, Heading, Prose };

--- a/src/features/profile/components/about.tsx
+++ b/src/features/profile/components/about.tsx
@@ -6,7 +6,7 @@ import { Panel, PanelContent, PanelHeader, PanelTitle } from "./panel";
 
 export function About() {
   return (
-    <Panel id="about" className="scroll-mt-22">
+    <Panel id="about">
       <PanelHeader>
         <PanelTitle>About</PanelTitle>
       </PanelHeader>

--- a/src/features/profile/components/awards/index.tsx
+++ b/src/features/profile/components/awards/index.tsx
@@ -13,7 +13,7 @@ const SORTED_AWARDS = [...AWARDS].sort((a, b) => {
 
 export function Awards() {
   return (
-    <Panel id="awards" className="scroll-mt-22">
+    <Panel id="awards">
       <PanelHeader>
         <PanelTitle>
           Awards

--- a/src/features/profile/components/blog.tsx
+++ b/src/features/profile/components/blog.tsx
@@ -12,7 +12,7 @@ export function Blog() {
   const allPosts = getAllPosts();
 
   return (
-    <Panel>
+    <Panel id="blog">
       <PanelHeader>
         <PanelTitle>Blog</PanelTitle>
       </PanelHeader>

--- a/src/features/profile/components/certifications/index.tsx
+++ b/src/features/profile/components/certifications/index.tsx
@@ -6,7 +6,7 @@ import { CertificationItem } from "./certification-item";
 
 export function Certifications() {
   return (
-    <Panel id="certs" className="scroll-mt-22">
+    <Panel id="certs">
       <PanelHeader>
         <PanelTitle>
           Certs

--- a/src/features/profile/components/experiences/index.tsx
+++ b/src/features/profile/components/experiences/index.tsx
@@ -11,7 +11,7 @@ export function Experiences() {
   );
 
   return (
-    <Panel id="experience" className="scroll-mt-22">
+    <Panel id="experience">
       <PanelHeader>
         <PanelTitle>Experience</PanelTitle>
       </PanelHeader>

--- a/src/features/profile/components/projects/index.tsx
+++ b/src/features/profile/components/projects/index.tsx
@@ -8,7 +8,7 @@ import { ProjectItem } from "./project-item";
 
 export function Projects() {
   return (
-    <Panel id="projects" className="scroll-mt-22">
+    <Panel id="projects">
       <PanelHeader>
         <PanelTitle>
           Projects

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -188,6 +188,10 @@
     scrollbar-width: thin;
     scrollbar-color: var(--d-border) transparent;
   }
+
+  [id] {
+    @apply scroll-mt-18;
+  }
 }
 
 @utility no-scrollbar {
@@ -204,15 +208,17 @@
   @apply font-medium underline underline-offset-4;
 }
 
-@utility rehype-pretty-code {
-  @apply my-6;
+@layer components {
+  [data-rehype-pretty-code-figure] {
+    @apply relative my-6;
 
-  pre {
-    @apply max-h-[512px] overflow-x-auto rounded-lg bg-zinc-900 py-4;
-  }
+    pre {
+      @apply max-h-[512px] overflow-x-auto rounded-lg bg-zinc-900 py-4;
+    }
 
-  code {
-    @apply font-mono text-sm;
+    code {
+      @apply font-mono text-sm;
+    }
   }
 
   [data-line] {
@@ -223,25 +229,25 @@
     @apply mb-2 px-4 text-sm font-medium;
   }
 
-  code[data-line-numbers] {
+  [data-line-numbers] {
     counter-reset: line;
   }
 
-  code[data-line-numbers] > [data-line]::before {
-    @apply mr-8 inline-block w-3 text-right text-xs text-muted-foreground;
+  [data-line-numbers] > [data-line]::before {
     counter-increment: line;
     content: counter(line);
+    @apply mr-8 inline-block w-3 text-right text-xs text-muted-foreground;
   }
 
-  code[data-line-numbers-max-digits="2"] > [data-line]::before {
+  [data-line-numbers-max-digits="2"] > [data-line]::before {
     @apply w-5;
   }
 
-  code[data-line-numbers-max-digits="3"] > [data-line]::before {
+  [data-line-numbers-max-digits="3"] > [data-line]::before {
     @apply w-7;
   }
 
-  code[data-line-numbers-max-digits="4"] > [data-line]::before {
+  [data-line-numbers-max-digits="4"] > [data-line]::before {
     @apply w-9;
   }
 }
@@ -256,11 +262,10 @@
 
 @utility step {
   counter-increment: step;
-
-  @apply before:bg-zinc-50 dark:before:bg-zinc-900;
+  @apply relative before:bg-zinc-50 dark:before:bg-zinc-900;
 
   &::before {
-    @apply mr-2 inline-flex size-8 items-center justify-center rounded-full border text-center -indent-px font-mono text-sm font-medium shadow-xs md:absolute md:-mt-0.5 md:-ml-11.5;
+    @apply mr-2 inline-flex size-7 items-center justify-center rounded-full border text-center -indent-px font-mono text-sm font-medium shadow-xs md:absolute md:-mt-0.5 md:-ml-11.5 md:size-8;
     content: counter(step);
   }
 }


### PR DESCRIPTION
refactor(typography): introduce Heading component for consistent heading styles

style(globals.css): apply consistent scroll margin and update rehype-pretty-code styles

fix(profile): remove redundant scroll-mt-22 class from Panel components

chore(package.json): add rehype-slug dependency for enhanced markdown processing