### PR TITLE
refactor(brand-context-menu.tsx): remove unused ContextMenuSeparator …

### DIFF
--- a/src/components/brand-context-menu.tsx
+++ b/src/components/brand-context-menu.tsx
@@ -13,7 +13,6 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
-  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "./ui/context-menu";
 
@@ -55,8 +54,6 @@ export function BrandContextMenu({ children }: { children: React.ReactNode }) {
             Brand Guidelines
           </Link>
         </ContextMenuItem>
-
-        <ContextMenuSeparator />
 
         <ContextMenuItem asChild>
           <a href="https://assets.chanhdai.com/chanhdai-brand.zip" download>

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -3,6 +3,7 @@
 import {
   BriefcaseBusinessIcon,
   ComponentIcon,
+  DownloadIcon,
   FileBadgeIcon,
   FilesIcon,
   FileTextIcon,
@@ -45,7 +46,7 @@ type CommandItemType = {
   iconImage?: string;
 };
 
-export const PAGES: CommandItemType[] = [
+const PAGES: CommandItemType[] = [
   {
     title: "Daifolio",
     value: "/",
@@ -315,6 +316,13 @@ export function CommandMenu() {
             >
               <TriangleDashedIcon />
               Brand Guidelines
+            </CommandItem>
+
+            <CommandItem asChild>
+              <a href="https://assets.chanhdai.com/chanhdai-brand.zip" download>
+                <DownloadIcon />
+                Download Brand Assets
+              </a>
             </CommandItem>
           </CommandGroup>
         </CommandList>


### PR DESCRIPTION
…to clean up the component

feat(command-menu.tsx): add Download Brand Assets option to enhance user access to brand resources
refactor(command-menu.tsx): change PAGES export to a local constant to limit its scope