### PR TITLE
feat(blog): add download links for brand assets in chanhdai-brand post

### DIFF
--- a/src/content/blog/chanhdai-brand.mdx
+++ b/src/content/blog/chanhdai-brand.mdx
@@ -22,6 +22,10 @@ updatedAt: 2025-06-01
   </svg>
 </figure>
 
+<a href="https://assets.chanhdai.com/images/chanhdai-mark.svg" download>
+  Download Mark
+</a>
+
 ## Logotype
 
 <figure>
@@ -37,6 +41,10 @@ updatedAt: 2025-06-01
     />
   </svg>
 </figure>
+
+<a href="https://assets.chanhdai.com/images/chanhdai-logotype.svg" download>
+  Download Logotype
+</a>
 
 ## Clear Space
 


### PR DESCRIPTION
Add download links for the Mark and Logotype to improve user access to brand assets directly from the blog post.