### PR TITLE
style(page.tsx, award-item.tsx, certification-item.tsx, experience-po…

### DIFF
--- a/src/app/(app)/(blog)/components/page.tsx
+++ b/src/app/(app)/(blog)/components/page.tsx
@@ -35,7 +35,7 @@ export default function Page() {
             aria-hidden
           />
 
-          <div className="border-l border-dashed border-edge px-2 py-4">
+          <div className="border-l border-dashed border-edge p-4">
             <h2 className="font-heading leading-snug font-medium text-balance decoration-(--color-react) underline-offset-4 group-hover/post:underline">
               {post.metadata.title}
             </h2>

--- a/src/features/profile/components/awards/award-item.tsx
+++ b/src/features/profile/components/awards/award-item.tsx
@@ -6,7 +6,6 @@ import React from "react";
 import { Icons } from "@/components/icons";
 import { Markdown } from "@/components/markdown";
 import { Prose } from "@/components/ui/typography";
-import { cn } from "@/lib/utils";
 
 import type { Award } from "../../types/awards";
 
@@ -21,56 +20,58 @@ export function AwardItem({
 
   return (
     <AccordionPrimitive.Item value={award.id} disabled={!canExpand} asChild>
-      <div className={cn("flex items-center", className)}>
-        <div
-          className="mx-4 flex size-6 shrink-0 items-center justify-center text-muted-foreground"
-          aria-hidden="true"
-        >
-          <Icons.award className="size-5" />
+      <div className={className}>
+        <div className="flex items-center">
+          <div
+            className="mx-4 flex size-6 shrink-0 items-center justify-center text-muted-foreground"
+            aria-hidden="true"
+          >
+            <Icons.award className="size-5" />
+          </div>
+
+          <div className="flex-1 border-l border-dashed border-edge">
+            <AccordionPrimitive.Trigger className="group/award flex w-full items-center justify-between gap-4 p-4 pr-2 text-left select-none [&[data-state=open]_.lucide-chevron-down]:rotate-180">
+              <div>
+                <h3 className="mb-1 flex items-center gap-1 font-heading leading-snug font-medium text-balance decoration-ring underline-offset-4 group-hover/award:underline group-disabled/award:no-underline">
+                  {award.title}
+                  {award.referenceLink && (
+                    <a
+                      className="flex size-6 shrink-0 items-center justify-center text-muted-foreground"
+                      href={award.referenceLink}
+                      target="_blank"
+                      rel="noopener"
+                    >
+                      <CircleCheckBigIcon className="pointer-events-none size-4" />
+                      <span className="sr-only">Open reference link</span>
+                    </a>
+                  )}
+                </h3>
+
+                <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+                  <span>{award.prize}</span>
+
+                  <span className="flex h-4 w-px shrink-0 bg-border" />
+                  <span>{dayjs(award.date).format("MM.YYYY")}</span>
+
+                  <span className="flex h-4 w-px shrink-0 bg-border" />
+                  <span>{award.grade}</span>
+                </p>
+              </div>
+
+              {canExpand && (
+                <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform duration-300" />
+              )}
+            </AccordionPrimitive.Trigger>
+          </div>
         </div>
 
-        <div className="flex-1 border-l border-dashed border-edge">
-          <AccordionPrimitive.Trigger className="group/award flex w-full items-center justify-between gap-4 px-2 py-4 text-left select-none [&[data-state=open]_.lucide-chevron-down]:rotate-180">
-            <div>
-              <h3 className="mb-1 flex items-center gap-1 font-heading leading-snug font-medium text-balance decoration-ring underline-offset-4 group-hover/award:underline group-disabled/award:no-underline">
-                {award.title}
-                {award.referenceLink && (
-                  <a
-                    className="flex size-6 shrink-0 items-center justify-center text-muted-foreground"
-                    href={award.referenceLink}
-                    target="_blank"
-                    rel="noopener"
-                  >
-                    <CircleCheckBigIcon className="pointer-events-none size-4" />
-                    <span className="sr-only">Open reference link</span>
-                  </a>
-                )}
-              </h3>
-
-              <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
-                <span>{award.prize}</span>
-
-                <span className="flex h-4 w-px shrink-0 bg-border" />
-                <span>{dayjs(award.date).format("MM.YYYY")}</span>
-
-                <span className="flex h-4 w-px shrink-0 bg-border" />
-                <span>{award.grade}</span>
-              </p>
-            </div>
-
-            {canExpand && (
-              <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform duration-300" />
-            )}
-          </AccordionPrimitive.Trigger>
-
-          {canExpand && (
-            <AccordionPrimitive.Content className="overflow-hidden transition-all duration-300 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-              <Prose className="px-2 pb-4">
-                <Markdown>{award.description}</Markdown>
-              </Prose>
-            </AccordionPrimitive.Content>
-          )}
-        </div>
+        {canExpand && (
+          <AccordionPrimitive.Content className="overflow-hidden duration-300 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+            <Prose className="border-t border-dashed border-edge p-4">
+              <Markdown>{award.description}</Markdown>
+            </Prose>
+          </AccordionPrimitive.Content>
+        )}
       </div>
     </AccordionPrimitive.Item>
   );

--- a/src/features/profile/components/certifications/certification-item.tsx
+++ b/src/features/profile/components/certifications/certification-item.tsx
@@ -41,7 +41,7 @@ export function CertificationItem({
         </div>
       )}
 
-      <div className="flex-1 space-y-1 border-l border-dashed border-edge px-2 py-4">
+      <div className="flex-1 space-y-1 border-l border-dashed border-edge p-4 pr-2">
         <h3 className="font-heading leading-snug font-medium text-balance decoration-ring underline-offset-4 group-hover/cert:underline">
           {certification.title}
         </h3>

--- a/src/features/profile/components/experiences/experience-position-item.tsx
+++ b/src/features/profile/components/experiences/experience-position-item.tsx
@@ -42,7 +42,7 @@ export function ExperiencePositionItem({
           </p>
         </AccordionPrimitive.Trigger>
 
-        <AccordionPrimitive.Content className="overflow-hidden transition-all duration-300 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+        <AccordionPrimitive.Content className="overflow-hidden duration-300 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
           {position.description && (
             <Prose className="pt-2 pl-9">
               <Markdown>{position.description}</Markdown>

--- a/src/features/profile/components/projects/project-item.tsx
+++ b/src/features/profile/components/projects/project-item.tsx
@@ -8,7 +8,6 @@ import { Markdown } from "@/components/markdown";
 import { Tag } from "@/components/ui/tag";
 import { Prose } from "@/components/ui/typography";
 import { UTM_PARAMS } from "@/config/site";
-import { cn } from "@/lib/utils";
 import { addQueryParams } from "@/utils/url";
 
 import type { Project } from "../../types/projects";
@@ -22,64 +21,68 @@ export function ProjectItem({
 }) {
   return (
     <AccordionPrimitive.Item value={project.id} asChild>
-      <div className={cn("flex items-center", className)}>
-        {project.logo ? (
-          <Image
-            src={project.logo}
-            alt={project.title}
-            width={32}
-            height={32}
-            quality={100}
-            className="mx-4 flex size-6 shrink-0"
-            unoptimized
-          />
-        ) : (
-          <div
-            className="mx-4 flex size-6 shrink-0 items-center justify-center text-muted-foreground"
-            aria-hidden="true"
-          >
-            <Icons.project className="size-5" />
-          </div>
-        )}
-
-        <div className="flex-1 border-l border-dashed border-edge">
-          <AccordionPrimitive.Trigger className="group/project flex w-full items-center justify-between gap-4 px-2 py-4 text-left select-none [&[data-state=open]_.lucide-chevron-down]:rotate-180">
-            <div>
-              <h3 className="mb-1 flex items-center gap-1 font-heading leading-snug font-medium text-balance decoration-ring underline-offset-4 group-hover/project:underline">
-                {project.title}
-                <a
-                  className="flex size-6 shrink-0 items-center justify-center text-muted-foreground"
-                  href={addQueryParams(project.link, UTM_PARAMS)}
-                  target="_blank"
-                  rel="noopener"
-                >
-                  <ArrowUpRightIcon className="pointer-events-none size-4" />
-                  <span className="sr-only">Open</span>
-                </a>
-              </h3>
-
-              <p className="text-sm text-muted-foreground">{project.time}</p>
+      <div className={className}>
+        <div className="flex items-center">
+          {project.logo ? (
+            <Image
+              src={project.logo}
+              alt={project.title}
+              width={32}
+              height={32}
+              quality={100}
+              className="mx-4 flex size-6 shrink-0"
+              unoptimized
+            />
+          ) : (
+            <div
+              className="mx-4 flex size-6 shrink-0 items-center justify-center text-muted-foreground"
+              aria-hidden="true"
+            >
+              <Icons.project className="size-5" />
             </div>
+          )}
 
-            <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform duration-300" />
-          </AccordionPrimitive.Trigger>
+          <div className="flex-1 border-l border-dashed border-edge">
+            <AccordionPrimitive.Trigger className="group/project flex w-full items-center justify-between gap-4 p-4 pr-2 text-left select-none [&[data-state=open]_.lucide-chevron-down]:rotate-180">
+              <div>
+                <h3 className="mb-1 flex items-center gap-1 font-heading leading-snug font-medium text-balance decoration-ring underline-offset-4 group-hover/project:underline">
+                  {project.title}
+                  <a
+                    className="flex size-6 shrink-0 items-center justify-center text-muted-foreground"
+                    href={addQueryParams(project.link, UTM_PARAMS)}
+                    target="_blank"
+                    rel="noopener"
+                  >
+                    <ArrowUpRightIcon className="pointer-events-none size-4" />
+                    <span className="sr-only">Open</span>
+                  </a>
+                </h3>
 
-          <AccordionPrimitive.Content className="space-y-4 overflow-hidden transition-all duration-300 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+                <p className="text-sm text-muted-foreground">{project.time}</p>
+              </div>
+
+              <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform duration-300" />
+            </AccordionPrimitive.Trigger>
+          </div>
+        </div>
+
+        <AccordionPrimitive.Content className="overflow-hidden duration-300 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+          <div className="space-y-4 border-t border-dashed border-edge p-4">
             {project.description && (
-              <Prose className="px-2">
+              <Prose>
                 <Markdown>{project.description}</Markdown>
               </Prose>
             )}
 
             {project.skills.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 px-2 pb-4">
+              <div className="flex flex-wrap gap-1.5">
                 {project.skills.map((skill, index) => (
                   <Tag key={index}>{skill}</Tag>
                 ))}
               </div>
             )}
-          </AccordionPrimitive.Content>
-        </div>
+          </div>
+        </AccordionPrimitive.Content>
       </div>
     </AccordionPrimitive.Item>
   );

--- a/src/features/profile/data/awards.ts
+++ b/src/features/profile/data/awards.ts
@@ -192,7 +192,8 @@ export const AWARDS: Award[] = [
     title: "Can Tho City Science and Engineering Fair 2018",
     date: "2018-01",
     grade: "Grade 12",
-    description: "- Field: System Software\n- Project: UnlimitedStudy",
+    description:
+      "- Field: System Software\n- Project: [UnlimitedStudy](https://muctim.tuoitre.vn/cong-cu-ho-tro-viec-day-va-hoc-55107.htm)",
     referenceLink:
       "https://drive.google.com/file/d/15PNdCA56653ZzvmZXqURR7eFLaU7pC8T/view?usp=sharing",
   },
@@ -214,7 +215,7 @@ export const AWARDS: Award[] = [
     date: "2018-03",
     grade: "Grade 12",
     description:
-      "- Organized in Lam Dong\n- Field: System Software\n- Project: UnlimitedStudy",
+      "- Organized in Lam Dong\n- Field: System Software\n- Project: [UnlimitedStudy](https://muctim.tuoitre.vn/cong-cu-ho-tro-viec-day-va-hoc-55107.htm)",
     referenceLink:
       "https://drive.google.com/file/d/1oOLM_ivrQ_IFHst66AC9qy3CoATT3z8B/view?usp=sharing",
   },
@@ -224,7 +225,8 @@ export const AWARDS: Award[] = [
     title: "Can Tho City Young Informatics Contest 2018",
     date: "2018-04",
     grade: "Grade 12",
-    description: "- Field: Creative Software\n- Project: UnlimitedStudy",
+    description:
+      "- Field: Creative Software\n- Project: [UnlimitedStudy](https://muctim.tuoitre.vn/cong-cu-ho-tro-viec-day-va-hoc-55107.htm)",
     referenceLink:
       "https://drive.google.com/file/d/1rh02NpKpPr7AQnXldQk8FGgbc837EPeQ/view?usp=sharing",
   },
@@ -234,7 +236,8 @@ export const AWARDS: Award[] = [
     title: "Can Tho City Youth and Children's Creativity Contest 2018",
     date: "2018-08",
     grade: "Grade 12",
-    description: "- Field: Software\n- Project: UnlimitedStudy",
+    description:
+      "- Field: Software\n- Project: [UnlimitedStudy](https://muctim.tuoitre.vn/cong-cu-ho-tro-viec-day-va-hoc-55107.htm)",
     referenceLink:
       "https://drive.google.com/file/d/1gWK5V29q6RMwZ8Qgsx6ZkRI7EzAd4n5e/view?usp=sharing",
   },
@@ -245,7 +248,7 @@ export const AWARDS: Award[] = [
     date: "2018-08",
     grade: "Grade 12",
     description:
-      "- Organized in Ba Ria - Vung Tau\n- Field: Creative Products\n- Project: UnlimitedStudy",
+      "- Organized in Ba Ria - Vung Tau\n- Field: Creative Products\n- Project: [UnlimitedStudy](https://muctim.tuoitre.vn/cong-cu-ho-tro-viec-day-va-hoc-55107.htm)",
     referenceLink:
       "https://drive.google.com/file/d/1Te5Ygi89H3j4pH5Yvm9ipDKEcghQXYy_/view?usp=sharing",
   },
@@ -256,7 +259,7 @@ export const AWARDS: Award[] = [
     date: "2019-05",
     grade: "University",
     description:
-      "- Organized by University of Economics and Law — VNUHCM\n- Project: Penphy — Self Development Social Network",
+      "- Organized by University of Economics and Law — VNUHCM\n- Project: [Penphy](https://www.youtube.com/watch?v=EdU7rUO-UA4) — Self Development Social Network",
     referenceLink:
       "https://drive.google.com/file/d/1A_bwayALMZIfd12wL85SVGwAHD8lJjgh/view?usp=sharing",
   },
@@ -267,7 +270,7 @@ export const AWARDS: Award[] = [
     grade: "University",
     date: "2022-11",
     description:
-      "- Organized by Ho Chi Minh City Youth Union\n- Field: Software\n- Project: ZaDark",
+      "- Organized by Ho Chi Minh City Youth Union\n- Field: Software\n- Project: [ZaDark](https://zadark.com)",
     referenceLink:
       "https://drive.google.com/file/d/1gmOG9_FTNAwdeR_eraYMCBBqaYuZOgoJ/view?usp=sharing",
   },

--- a/src/features/profile/data/projects.ts
+++ b/src/features/profile/data/projects.ts
@@ -178,6 +178,7 @@ Blog Features:
 - 3rd Prize — Can Tho City Young Informatics Contest 2018
 - Reached 7,000+ users, mainly high school students in Can Tho City.
 - Pilot implemented in high schools across Can Tho City with English quizzes, supervised by English subject specialists from the Can Tho City Department of Education and Training.`,
+    logo: "https://assets.chanhdai.com/images/project-logos/unlimitedstudy.webp",
   },
   {
     id: "dmessage",


### PR DESCRIPTION
…sition-item.tsx, project-item.tsx): unify padding styles for consistency

refactor(award-item.tsx, project-item.tsx): remove unused 'cn' import to clean up code

docs(awards.ts): add hyperlinks to project names in award descriptions for better context and accessibility

feat(projects.ts): add logo URL for 'UnlimitedStudy' project to enhance visual representation