### PR TITLE
refactor(json): move @tailwindcss/typography to devDependencies

### DIFF
--- a/public/r/work-experience.json
+++ b/public/r/work-experience.json
@@ -4,8 +4,10 @@
   "type": "registry:component",
   "dependencies": [
     "react-markdown",
-    "@tailwindcss/typography",
     "lucide-react"
+  ],
+  "devDependencies": [
+    "@tailwindcss/typography"
   ],
   "registryDependencies": [
     "https://chanhdai.com/r/utils.json",

--- a/src/__registry__/registry.autogenerated.json
+++ b/src/__registry__/registry.autogenerated.json
@@ -102,8 +102,10 @@
       "type": "registry:component",
       "dependencies": [
         "react-markdown",
-        "@tailwindcss/typography",
         "lucide-react"
+      ],
+      "devDependencies": [
+        "@tailwindcss/typography"
       ],
       "registryDependencies": [
         "https://chanhdai.com/r/utils.json",

--- a/src/registry/registry-components.ts
+++ b/src/registry/registry-components.ts
@@ -52,7 +52,8 @@ export const components: Registry["items"] = [
   {
     name: "work-experience",
     type: "registry:component",
-    dependencies: ["react-markdown", "@tailwindcss/typography", "lucide-react"],
+    dependencies: ["react-markdown", "lucide-react"],
+    devDependencies: ["@tailwindcss/typography"],
     registryDependencies: [
       "https://chanhdai.com/r/utils.json",
       "collapsible",


### PR DESCRIPTION
Move @tailwindcss/typography from dependencies to devDependencies in work-experience.json, registry.autogenerated.json, and registry-components.ts to reflect its usage only in development environment. This change helps in reducing the production bundle size.