### PR TITLE
style: update shadow color in dark mode for consistency

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -193,7 +193,7 @@ export function CommandMenu({ posts }: { posts: Post[] }) {
         variant="secondary"
         className={cn(
           "h-8 gap-1.5 rounded-full bg-zinc-50 px-2.5 text-muted-foreground select-none hover:bg-zinc-50 dark:bg-zinc-900 dark:hover:bg-zinc-900",
-          "not-dark:border dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-zinc-600"
+          "not-dark:border dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-white/15"
         )}
         onClick={() => setOpen(true)}
       >

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,13 +12,13 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-linear-to-b from-zinc-700 to-zinc-800 text-white transition-colors text-shadow-xs hover:to-zinc-700 dark:from-zinc-600 dark:to-zinc-700 dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-zinc-400 dark:hover:to-zinc-600",
+          "bg-linear-to-b from-zinc-700 to-zinc-800 text-white transition-colors text-shadow-xs hover:to-zinc-700 dark:from-zinc-600 dark:to-zinc-700 dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-white/20 dark:hover:to-zinc-600",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-white/15",
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
         outline:
-          "bg-background not-dark:border not-dark:border-input hover:bg-accent hover:text-accent-foreground dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-zinc-600",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-foreground underline-offset-4 hover:underline",
       },

--- a/src/features/profile/components/experiences/experience-position-item.tsx
+++ b/src/features/profile/components/experiences/experience-position-item.tsx
@@ -32,7 +32,7 @@ export function ExperiencePositionItem({
         <CollapsibleTrigger className="group/experience block w-full text-left select-none">
           <div className="relative z-1 mb-1 flex items-center gap-3 bg-background">
             <div
-              className="flex size-6 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-zinc-600"
+              className="flex size-6 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-white/15"
               aria-hidden
             >
               <ExperienceIcon className="size-4" icon={position.icon} />

--- a/src/features/profile/components/overview/intro-item.tsx
+++ b/src/features/profile/components/overview/intro-item.tsx
@@ -12,7 +12,7 @@ export function IntroItem({
   return (
     <div className="flex items-center gap-4 font-mono text-sm">
       <div
-        className="flex size-6 shrink-0 items-center justify-center rounded-lg bg-muted dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-zinc-600"
+        className="flex size-6 shrink-0 items-center justify-center rounded-lg bg-muted dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-white/15"
         aria-hidden
       >
         <Icon className="pointer-events-none size-4 text-muted-foreground" />


### PR DESCRIPTION
Change dark mode inset shadow color from zinc-600 to white with opacity for consistent appearance across components. Adjust secondary button variant to include dark mode shadow styling.