### PR TITLE
refactor(components): replace CollapsibleTriggerWithSound with Collap…

### DIFF
--- a/src/components/code-collapsible-wrapper.tsx
+++ b/src/components/code-collapsible-wrapper.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import {
   Collapsible,
   CollapsibleContent,
-  CollapsibleTriggerWithSound,
+  CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
@@ -19,7 +19,7 @@ export function CodeCollapsibleWrapper({
       className={cn("group/collapsible not-prose relative my-6", className)}
       {...props}
     >
-      <CollapsibleTriggerWithSound asChild>
+      <CollapsibleTrigger asChild>
         <div className="absolute top-2 right-10 z-10 flex items-center gap-2">
           <Button className="size-6 rounded-md" variant="secondary" size="icon">
             <ChevronsDownUpIcon className="hidden group-data-[state=open]/collapsible:block" />
@@ -31,7 +31,7 @@ export function CodeCollapsibleWrapper({
             orientation="vertical"
           />
         </div>
-      </CollapsibleTriggerWithSound>
+      </CollapsibleTrigger>
 
       <CollapsibleContent
         className="overflow-hidden data-[state=closed]:max-h-80 data-[state=closed]:rounded-b-lg [&>figure]:my-0"
@@ -40,9 +40,9 @@ export function CodeCollapsibleWrapper({
         {children}
       </CollapsibleContent>
 
-      <CollapsibleTriggerWithSound className="absolute inset-x-0 bottom-0 flex h-24 items-end justify-center rounded-b-lg bg-linear-to-t from-code from-25% to-transparent pb-4 text-sm font-medium text-muted-foreground group-data-[state=open]/collapsible:hidden">
+      <CollapsibleTrigger className="absolute inset-x-0 bottom-0 flex h-24 items-end justify-center rounded-b-lg bg-linear-to-t from-code from-25% to-transparent pb-4 text-sm font-medium text-muted-foreground group-data-[state=open]/collapsible:hidden">
         Expand
-      </CollapsibleTriggerWithSound>
+      </CollapsibleTrigger>
     </Collapsible>
   );
 }

--- a/src/components/collapsible-list.tsx
+++ b/src/components/collapsible-list.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import {
   Collapsible,
   CollapsibleContent,
-  CollapsibleTriggerWithSound,
+  CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 
 const Slot = SlotPrimitive.Slot;
@@ -52,7 +52,7 @@ export function CollapsibleList<T>({
 
       {items.length > max && (
         <div className="flex h-12 items-center justify-center pb-px">
-          <CollapsibleTriggerWithSound asChild>
+          <CollapsibleTrigger asChild>
             <Button
               className="group/collapsible-trigger flex"
               variant="default"
@@ -70,7 +70,7 @@ export function CollapsibleList<T>({
                 aria-hidden
               />
             </Button>
-          </CollapsibleTriggerWithSound>
+          </CollapsibleTrigger>
         </div>
       )}
     </Collapsible>

--- a/src/components/inline-toc.tsx
+++ b/src/components/inline-toc.tsx
@@ -4,7 +4,7 @@ import { ChevronsDownUpIcon, ChevronsUpDownIcon } from "lucide-react";
 import {
   Collapsible,
   CollapsibleContent,
-  CollapsibleTriggerWithSound,
+  CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 
@@ -25,7 +25,7 @@ export function InlineTOC({
       className={cn("not-prose rounded-lg bg-code font-sans", className)}
       {...props}
     >
-      <CollapsibleTriggerWithSound className="group/toc inline-flex w-full items-center justify-between px-4 py-3 text-sm font-medium">
+      <CollapsibleTrigger className="group/toc inline-flex w-full items-center justify-between px-4 py-3 text-sm font-medium">
         {children ?? "Table of Contents"}
         <div
           className="shrink-0 text-muted-foreground [&_svg]:size-4"
@@ -34,7 +34,7 @@ export function InlineTOC({
           <ChevronsDownUpIcon className="hidden group-data-[state=open]/toc:block" />
           <ChevronsUpDownIcon className="hidden group-data-[state=closed]/toc:block" />
         </div>
-      </CollapsibleTriggerWithSound>
+      </CollapsibleTrigger>
 
       <CollapsibleContent className="overflow-hidden duration-300 data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
         <ul className="flex flex-col px-4 pb-3 text-sm text-muted-foreground">

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -2,37 +2,10 @@
 
 import { Collapsible as CollapsiblePrimitive } from "radix-ui";
 
-import { useClickSound } from "@/hooks/use-click-sound";
-
 const Collapsible = CollapsiblePrimitive.Root;
 
 const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
 
-function CollapsibleTriggerWithSound({
-  children,
-  onClick,
-  ...props
-}: React.ComponentProps<typeof CollapsibleTrigger>) {
-  const playClick = useClickSound();
-
-  return (
-    <CollapsibleTrigger
-      {...props}
-      onClick={(e) => {
-        playClick();
-        onClick?.(e);
-      }}
-    >
-      {children}
-    </CollapsibleTrigger>
-  );
-}
-
 const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
 
-export {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-  CollapsibleTriggerWithSound,
-};
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/src/features/profile/components/awards/award-item.tsx
+++ b/src/features/profile/components/awards/award-item.tsx
@@ -10,7 +10,7 @@ import { Markdown } from "@/components/markdown";
 import {
   Collapsible,
   CollapsibleContent,
-  CollapsibleTriggerWithSound,
+  CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Separator } from "@/components/ui/separator";
 import { SimpleTooltip } from "@/components/ui/tooltip";
@@ -39,7 +39,7 @@ export function AwardItem({
           </div>
 
           <div className="flex-1 border-l border-dashed border-edge">
-            <CollapsibleTriggerWithSound className="group/award flex w-full items-center gap-4 p-4 pr-2 text-left select-none">
+            <CollapsibleTrigger className="group/award flex w-full items-center gap-4 p-4 pr-2 text-left select-none">
               <div className="flex-1">
                 <h3 className="mb-1 leading-snug font-medium text-balance">
                   {award.title}
@@ -103,7 +103,7 @@ export function AwardItem({
                   <ChevronsUpDownIcon className="hidden group-data-[state=closed]/award:block" />
                 </div>
               )}
-            </CollapsibleTriggerWithSound>
+            </CollapsibleTrigger>
           </div>
         </div>
 

--- a/src/features/profile/components/experiences/experience-position-item.tsx
+++ b/src/features/profile/components/experiences/experience-position-item.tsx
@@ -9,7 +9,7 @@ import { Markdown } from "@/components/markdown";
 import {
   Collapsible,
   CollapsibleContent,
-  CollapsibleTriggerWithSound,
+  CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Separator } from "@/components/ui/separator";
 import { Tag } from "@/components/ui/tag";
@@ -29,7 +29,7 @@ export function ExperiencePositionItem({
   return (
     <Collapsible defaultOpen={position.isExpanded} asChild>
       <div className="relative last:before:absolute last:before:h-full last:before:w-4 last:before:bg-background">
-        <CollapsibleTriggerWithSound className="group/experience block w-full text-left select-none">
+        <CollapsibleTrigger className="group/experience block w-full text-left select-none">
           <div className="relative z-1 mb-1 flex items-center gap-3 bg-background">
             <div
               className="flex size-6 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground dark:inset-shadow-[1px_1px_1px,0px_0px_1px] dark:inset-shadow-white/15"
@@ -85,7 +85,7 @@ export function ExperiencePositionItem({
               </dd>
             </dl>
           </div>
-        </CollapsibleTriggerWithSound>
+        </CollapsibleTrigger>
 
         <CollapsibleContent className="overflow-hidden duration-300 data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
           {position.description && (

--- a/src/features/profile/components/projects/project-item.tsx
+++ b/src/features/profile/components/projects/project-item.tsx
@@ -12,7 +12,7 @@ import { Markdown } from "@/components/markdown";
 import {
   Collapsible,
   CollapsibleContent,
-  CollapsibleTriggerWithSound,
+  CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Tag } from "@/components/ui/tag";
 import { SimpleTooltip } from "@/components/ui/tooltip";
@@ -57,7 +57,7 @@ export function ProjectItem({
           )}
 
           <div className="flex-1 border-l border-dashed border-edge">
-            <CollapsibleTriggerWithSound className="group/project flex w-full items-center gap-4 p-4 pr-2 text-left select-none">
+            <CollapsibleTrigger className="group/project flex w-full items-center gap-4 p-4 pr-2 text-left select-none">
               <div className="flex-1">
                 <h3 className="mb-1 leading-snug font-medium text-balance">
                   {project.title}
@@ -102,7 +102,7 @@ export function ProjectItem({
                 <ChevronsDownUpIcon className="hidden group-data-[state=open]/project:block" />
                 <ChevronsUpDownIcon className="hidden group-data-[state=closed]/project:block" />
               </div>
-            </CollapsibleTriggerWithSound>
+            </CollapsibleTrigger>
           </div>
         </div>
 


### PR DESCRIPTION
…sibleTrigger

Remove the use of CollapsibleTriggerWithSound in favor of CollapsibleTrigger to simplify the codebase. This change eliminates the dependency on the useClickSound hook, reducing complexity and potential side effects related to sound playback on trigger actions.