### PR TITLE
feat(registry): add new work-experience-block-01 to registry

### DIFF
--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -187,6 +187,19 @@
           "type": "registry:component"
         }
       ]
+    },
+    {
+      "name": "work-experience-block-01",
+      "type": "registry:block",
+      "registryDependencies": [
+        "https://chanhdai.com/r/work-experience.json"
+      ],
+      "files": [
+        {
+          "path": "src/registry/examples/work-experience-demo.tsx",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }

--- a/public/r/work-experience-block-01.json
+++ b/public/r/work-experience-block-01.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "work-experience-block-01",
+  "type": "registry:block",
+  "registryDependencies": [
+    "https://chanhdai.com/r/work-experience.json"
+  ],
+  "files": [
+    {
+      "path": "src/registry/examples/work-experience-demo.tsx",
+      "content": "import type { ExperienceItemType } from \"@/registry/work-experience\";\nimport { WorkExperience } from \"@/registry/work-experience\";\n\nconst WORK_EXPERIENCE: ExperienceItemType[] = [\n  {\n    id: \"quaric\",\n    companyName: \"Quaric Co., Ltd.\",\n    companyLogo: \"https://assets.chanhdai.com/images/companies/quaric.svg\",\n    positions: [\n      {\n        id: \"30d3a9fb-021d-452a-9d27-83655369b4b9\",\n        title: \"Software Engineer\",\n        employmentPeriod: \"03.2024 — present\",\n        employmentType: \"Part-time\",\n        icon: \"code\",\n        description: `- Integrated VNPAY-QR for secure transactions.\n- Registered the e-commerce site with [online.gov.vn](https://online.gov.vn) for compliance.\n- Developed online ordering to streamline purchases.\n- Build and maintain ZaDark.com with Docusaurus, integrating AdSense.\n- Develop and maintain the ZaDark extension for Zalo Web on Chrome, Safari, Edge, and Firefox — with 15,000+ active users via Chrome Web Store.`,\n        skills: [\n          \"Next.js\",\n          \"Strapi\",\n          \"Auth0\",\n          \"VNPAY-QR\",\n          \"Docker\",\n          \"NGINX\",\n          \"Google Cloud\",\n          \"Docusaurus\",\n          \"Extension\",\n          \"Research\",\n          \"Project Management\",\n        ],\n        isExpanded: true,\n      },\n      {\n        id: \"7586afb2-40e8-49c4-8983-2254c9446540\",\n        title: \"Product Designer\",\n        employmentPeriod: \"03.2024 — present\",\n        employmentType: \"Part-time\",\n        icon: \"design\",\n        description: `- Design UI/UX for Quaric Website with a seamless experience.\n- Develop a Design System for consistency and efficiency.\n- Create Quaric's brand identity, including logo and guidelines.`,\n        skills: [\n          \"UI/UX Design\",\n          \"UX Writing\",\n          \"Design System\",\n          \"Brand Design\",\n          \"Figma\",\n        ],\n      },\n      {\n        id: \"991692c4-7d02-4666-8d31-933c4831768d\",\n        title: \"Founder & Director\",\n        employmentPeriod: \"03.2024 — present\",\n        employmentType: \"Part-time\",\n        icon: \"business\",\n        description: `- Lead and manage the company's strategy.\n- Oversee technical teams and product development.\n- Manage relationships with customers and partners.`,\n        skills: [\"Business Ownership\", \"Business Law\", \"Business Tax\"],\n      },\n    ],\n    isCurrentEmployer: true,\n  },\n];\n\nexport default function WorkExperienceDemo() {\n  return (\n    <WorkExperience\n      className=\"w-full rounded-lg border\"\n      experiences={WORK_EXPERIENCE}\n    />\n  );\n}\n",
+      "type": "registry:component"
+    }
+  ]
+}

--- a/src/__registry__/index.tsx
+++ b/src/__registry__/index.tsx
@@ -91,6 +91,15 @@ export const Index: Record<string, any> = {
       type: "registry:component",
     }],
   },
+  "work-experience-block-01": {
+    name: "work-experience-block-01",
+    description: "",
+    type: "registry:block",
+    files: [{
+      path: "src/registry/examples/work-experience-demo.tsx",
+      type: "registry:component",
+    }],
+  },
   "apple-hello-effect-vi-demo": {
     name: "apple-hello-effect-vi-demo",
     description: "",

--- a/src/__registry__/registry.autogenerated.json
+++ b/src/__registry__/registry.autogenerated.json
@@ -187,6 +187,19 @@
           "type": "registry:component"
         }
       ]
+    },
+    {
+      "name": "work-experience-block-01",
+      "type": "registry:block",
+      "registryDependencies": [
+        "https://chanhdai.com/r/work-experience.json"
+      ],
+      "files": [
+        {
+          "path": "src/registry/examples/work-experience-demo.tsx",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }

--- a/src/components/component-preview.tsx
+++ b/src/components/component-preview.tsx
@@ -59,7 +59,7 @@ export function ComponentPreview({
         <TabsContent value="preview">
           <div className="rounded-lg border border-edge bg-zinc-950/0.75 bg-[radial-gradient(var(--pattern-foreground)_1px,transparent_0)] bg-size-[10px_10px] bg-center p-4 [--pattern-foreground:var(--color-zinc-950)]/5 dark:bg-white/0.75 dark:[--pattern-foreground:var(--color-white)]/5">
             {(canReplay || openInV0Url) && (
-              <div className="flex justify-end gap-2">
+              <div className="mb-4 flex justify-end gap-2">
                 {canReplay && (
                   <SimpleTooltip content="Replay">
                     <Button

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -129,7 +129,7 @@ const components: MDXRemoteProps["components"] = {
   TabsTrigger,
   TabsContent,
   TabsTriggerShadcnCLI: () => (
-    <TabsTrigger value="cli">
+    <TabsTrigger className="pl-2" value="cli">
       <Icons.shadcn />
       shadcn CLI
     </TabsTrigger>

--- a/src/features/blog/content/work-experience-component.mdx
+++ b/src/features/blog/content/work-experience-component.mdx
@@ -9,6 +9,7 @@ updatedAt: 2025-06-16
 
 <ComponentPreview
   name="work-experience-demo"
+  openInV0Url="https://chanhdai.com/r/work-experience-block-01.json"
   notProse={false}
   codeCollapsible
 />
@@ -179,6 +180,7 @@ type ExperienceItemType = {
 
 <ComponentPreview
   name="work-experience-demo"
+  openInV0Url="https://chanhdai.com/r/work-experience-block-01.json"
   notProse={false}
   codeCollapsible
 />

--- a/src/registry/registry-blocks.ts
+++ b/src/registry/registry-blocks.ts
@@ -29,4 +29,15 @@ export const blocks: Registry["items"] = [
       },
     ],
   },
+  {
+    name: "work-experience-block-01",
+    type: "registry:block",
+    registryDependencies: ["<registryBaseUrl>/work-experience.json"],
+    files: [
+      {
+        path: "examples/work-experience-demo.tsx",
+        type: "registry:component",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
Add work-experience-block-01 to registry.json and registry-blocks.ts to provide a new block for displaying work experience. This block includes dependencies and a demo component for showcasing its usage.

style(component-preview): add margin-bottom to button container

Improve layout by adding margin-bottom to the button container in ComponentPreview for better spacing.

style(mdx): add padding to TabsTrigger for better alignment

Enhance the visual alignment of the TabsTrigger component by adding padding to the CLI tab.

docs(blog): update work-experience-component.mdx with openInV0Url

Include openInV0Url in the work-experience-component.mdx to provide a direct link to the work-experience-block-01.json for easier access.