### PR TITLE
refactor: update registry dependencies to use package names instead o…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,9 @@
     "strings": "on"
   },
   "editor.colorDecorators": false,
+  "material-icon-theme.files.associations": {
+    "components.json": "../../icons/shadcn"
+  },
   "tailwindCSS.experimental.classRegex": [
     [
       "cva\\(((?:[^()]|\\([^()]*\\))*)\\)",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,12 +64,12 @@ This project utilizes **shadcn Registry**, which allows you to manage and distri
 If you're working on a different React project and want to reuse the custom components from this repository, you can add them using the **shadcn CLI** with the following commands:
 
 ```bash
-npx shadcn@latest add https://chanhdai.com/r/utils.json
-npx shadcn@latest add https://chanhdai.com/r/theme-switcher.json
-npx shadcn@latest add https://chanhdai.com/r/flip-sentences.json
-npx shadcn@latest add https://chanhdai.com/r/apple-hello-effect.json
-npx shadcn@latest add https://chanhdai.com/r/wheel-picker.json
-npx shadcn@latest add https://chanhdai.com/r/use-controllable-state.json
+npx shadcn@latest add @ncdai/utils
+npx shadcn@latest add @ncdai/theme-switcher
+npx shadcn@latest add @ncdai/flip-sentences
+npx shadcn@latest add @ncdai/apple-hello-effect
+npx shadcn@latest add @ncdai/wheel-picker
+npx shadcn@latest add @ncdai/use-controllable-state
 ```
 
 > Note: These components are compatible with [Tailwind CSS v4](https://tailwindcss.com/blog/tailwindcss-v4) and [React 19](https://react.dev/blog/2024/12/05/react-19).

--- a/components.json
+++ b/components.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
-  "registries": {
-    "@ncdai": "https://chanhdai.com/r/{name}.json"
-  },
   "style": "default",
   "rsc": true,
   "tsx": true,

--- a/public/r/apple-hello-effect.json
+++ b/public/r/apple-hello-effect.json
@@ -9,7 +9,7 @@
     "motion"
   ],
   "registryDependencies": [
-    "https://chanhdai.com/r/utils.json"
+    "@ncdai/utils"
   ],
   "files": [
     {

--- a/public/r/flip-sentences.json
+++ b/public/r/flip-sentences.json
@@ -8,7 +8,7 @@
     "motion"
   ],
   "registryDependencies": [
-    "https://chanhdai.com/r/utils.json"
+    "@ncdai/utils"
   ],
   "files": [
     {

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -46,7 +46,7 @@
         "motion"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/utils.json"
+        "@ncdai/utils"
       ],
       "files": [
         {
@@ -65,7 +65,7 @@
         "motion"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/utils.json"
+        "@ncdai/utils"
       ],
       "files": [
         {
@@ -84,7 +84,7 @@
         "motion"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/utils.json"
+        "@ncdai/utils"
       ],
       "files": [
         {
@@ -104,7 +104,7 @@
         "@ncdai/react-wheel-picker"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/utils.json"
+        "@ncdai/utils"
       ],
       "files": [
         {
@@ -128,7 +128,7 @@
         "@tailwindcss/typography"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/utils.json",
+        "@ncdai/utils",
         "collapsible",
         "separator"
       ],
@@ -158,7 +158,7 @@
       "name": "wheel-picker-block-01",
       "type": "registry:block",
       "registryDependencies": [
-        "https://chanhdai.com/r/wheel-picker.json"
+        "@ncdai/wheel-picker"
       ],
       "files": [
         {
@@ -176,7 +176,7 @@
         "zod"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/wheel-picker.json",
+        "@ncdai/wheel-picker",
         "form",
         "button",
         "sonner"
@@ -192,7 +192,7 @@
       "name": "work-experience-block-01",
       "type": "registry:block",
       "registryDependencies": [
-        "https://chanhdai.com/r/work-experience.json"
+        "@ncdai/work-experience"
       ],
       "files": [
         {

--- a/public/r/theme-switcher.json
+++ b/public/r/theme-switcher.json
@@ -11,7 +11,7 @@
     "motion"
   ],
   "registryDependencies": [
-    "https://chanhdai.com/r/utils.json"
+    "@ncdai/utils"
   ],
   "files": [
     {

--- a/public/r/wheel-picker-block-01.json
+++ b/public/r/wheel-picker-block-01.json
@@ -3,7 +3,7 @@
   "name": "wheel-picker-block-01",
   "type": "registry:block",
   "registryDependencies": [
-    "https://chanhdai.com/r/wheel-picker.json"
+    "@ncdai/wheel-picker"
   ],
   "files": [
     {

--- a/public/r/wheel-picker-block-02.json
+++ b/public/r/wheel-picker-block-02.json
@@ -8,7 +8,7 @@
     "zod"
   ],
   "registryDependencies": [
-    "https://chanhdai.com/r/wheel-picker.json",
+    "@ncdai/wheel-picker",
     "form",
     "button",
     "sonner"

--- a/public/r/wheel-picker.json
+++ b/public/r/wheel-picker.json
@@ -9,7 +9,7 @@
     "@ncdai/react-wheel-picker"
   ],
   "registryDependencies": [
-    "https://chanhdai.com/r/utils.json"
+    "@ncdai/utils"
   ],
   "files": [
     {

--- a/public/r/work-experience-block-01.json
+++ b/public/r/work-experience-block-01.json
@@ -3,7 +3,7 @@
   "name": "work-experience-block-01",
   "type": "registry:block",
   "registryDependencies": [
-    "https://chanhdai.com/r/work-experience.json"
+    "@ncdai/work-experience"
   ],
   "files": [
     {

--- a/public/r/work-experience.json
+++ b/public/r/work-experience.json
@@ -13,7 +13,7 @@
     "@tailwindcss/typography"
   ],
   "registryDependencies": [
-    "https://chanhdai.com/r/utils.json",
+    "@ncdai/utils",
     "collapsible",
     "separator"
   ],

--- a/src/__registry__/registry.autogenerated.json
+++ b/src/__registry__/registry.autogenerated.json
@@ -46,7 +46,7 @@
         "motion"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/utils.json"
+        "@ncdai/utils"
       ],
       "files": [
         {
@@ -65,7 +65,7 @@
         "motion"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/utils.json"
+        "@ncdai/utils"
       ],
       "files": [
         {
@@ -84,7 +84,7 @@
         "motion"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/utils.json"
+        "@ncdai/utils"
       ],
       "files": [
         {
@@ -104,7 +104,7 @@
         "@ncdai/react-wheel-picker"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/utils.json"
+        "@ncdai/utils"
       ],
       "files": [
         {
@@ -128,7 +128,7 @@
         "@tailwindcss/typography"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/utils.json",
+        "@ncdai/utils",
         "collapsible",
         "separator"
       ],
@@ -158,7 +158,7 @@
       "name": "wheel-picker-block-01",
       "type": "registry:block",
       "registryDependencies": [
-        "https://chanhdai.com/r/wheel-picker.json"
+        "@ncdai/wheel-picker"
       ],
       "files": [
         {
@@ -176,7 +176,7 @@
         "zod"
       ],
       "registryDependencies": [
-        "https://chanhdai.com/r/wheel-picker.json",
+        "@ncdai/wheel-picker",
         "form",
         "button",
         "sonner"
@@ -192,7 +192,7 @@
       "name": "work-experience-block-01",
       "type": "registry:block",
       "registryDependencies": [
-        "https://chanhdai.com/r/work-experience.json"
+        "@ncdai/work-experience"
       ],
       "files": [
         {

--- a/src/features/blog/content/react-wheel-picker.mdx
+++ b/src/features/blog/content/react-wheel-picker.mdx
@@ -29,7 +29,7 @@ The Wheel Picker component is built on top of [React Wheel Picker](https://react
 <TabsContent value="cli" className="[&>figure]:mb-0">
 
 ```bash
-npx shadcn@latest add https://chanhdai.com/r/wheel-picker.json
+npx shadcn@latest add @ncdai/wheel-picker
 ```
 
 </TabsContent>

--- a/src/features/blog/content/theme-switcher-component.mdx
+++ b/src/features/blog/content/theme-switcher-component.mdx
@@ -24,7 +24,7 @@ updatedAt: 2025-04-11
 <TabsContent value="cli" className="[&>figure]:mb-0">
 
 ```bash
-npx shadcn@latest add https://chanhdai.com/r/theme-switcher.json
+npx shadcn@latest add @ncdai/theme-switcher
 ```
 
 </TabsContent>

--- a/src/features/blog/content/work-experience-component.mdx
+++ b/src/features/blog/content/work-experience-component.mdx
@@ -26,7 +26,7 @@ updatedAt: 2025-06-16
 <TabsContent value="cli" className="[&>figure]:last:mb-0">
 
 ```bash
-npx shadcn@latest add https://chanhdai.com/r/work-experience.json
+npx shadcn@latest add @ncdai/work-experience
 ```
 
 Add the `@tailwindcss/typography` plugin:

--- a/src/features/blog/content/writing-effect-inspired-by-apple.mdx
+++ b/src/features/blog/content/writing-effect-inspired-by-apple.mdx
@@ -31,7 +31,7 @@ updatedAt: 2025-04-11
 <TabsContent value="cli" className="[&>figure]:mb-0">
 
 ```bash
-npx shadcn@latest add https://chanhdai.com/r/apple-hello-effect.json
+npx shadcn@latest add @ncdai/apple-hello-effect
 ```
 
 </TabsContent>

--- a/src/registry/registry-blocks.ts
+++ b/src/registry/registry-blocks.ts
@@ -4,7 +4,7 @@ export const blocks: Registry["items"] = [
   {
     name: "wheel-picker-block-01",
     type: "registry:block",
-    registryDependencies: ["<registryBaseUrl>/wheel-picker.json"],
+    registryDependencies: ["@ncdai/wheel-picker"],
     files: [
       {
         path: "examples/wheel-picker-demo.tsx",
@@ -16,12 +16,7 @@ export const blocks: Registry["items"] = [
     name: "wheel-picker-block-02",
     type: "registry:block",
     dependencies: ["react-hook-form", "@hookform/resolvers", "zod"],
-    registryDependencies: [
-      "<registryBaseUrl>/wheel-picker.json",
-      "form",
-      "button",
-      "sonner",
-    ],
+    registryDependencies: ["@ncdai/wheel-picker", "form", "button", "sonner"],
     files: [
       {
         path: "examples/wheel-picker-form-demo.tsx",
@@ -32,7 +27,7 @@ export const blocks: Registry["items"] = [
   {
     name: "work-experience-block-01",
     type: "registry:block",
-    registryDependencies: ["<registryBaseUrl>/work-experience.json"],
+    registryDependencies: ["@ncdai/work-experience"],
     files: [
       {
         path: "examples/work-experience-demo.tsx",

--- a/src/registry/registry-components.ts
+++ b/src/registry/registry-components.ts
@@ -9,7 +9,7 @@ export const components: Registry["items"] = [
     title: "Theme Switcher",
     author: "ncdai <dai@chanhdai.com>",
     dependencies: ["next-themes", "lucide-react", "motion"],
-    registryDependencies: ["<registryBaseUrl>/utils.json"],
+    registryDependencies: ["@ncdai/utils"],
     files: [
       {
         path: "theme-switcher/theme-switcher.tsx",
@@ -24,7 +24,7 @@ export const components: Registry["items"] = [
     title: "Flip Sentences",
     author: "ncdai <dai@chanhdai.com>",
     dependencies: ["motion"],
-    registryDependencies: ["<registryBaseUrl>/utils.json"],
+    registryDependencies: ["@ncdai/utils"],
     files: [
       {
         path: "flip-sentences/flip-sentences.tsx",
@@ -40,7 +40,7 @@ export const components: Registry["items"] = [
     title: "Apple Hello Effect",
     author: "ncdai <dai@chanhdai.com>",
     dependencies: ["motion"],
-    registryDependencies: ["<registryBaseUrl>/utils.json"],
+    registryDependencies: ["@ncdai/utils"],
     files: [
       {
         path: "apple-hello-effect/apple-hello-effect.tsx",
@@ -57,7 +57,7 @@ export const components: Registry["items"] = [
     title: "Wheel Picker",
     author: "ncdai <dai@chanhdai.com>",
     dependencies: ["@ncdai/react-wheel-picker"],
-    registryDependencies: ["<registryBaseUrl>/utils.json"],
+    registryDependencies: ["@ncdai/utils"],
     files: [
       {
         path: "wheel-picker/wheel-picker.tsx",
@@ -75,11 +75,7 @@ export const components: Registry["items"] = [
     author: "ncdai <dai@chanhdai.com>",
     dependencies: ["react-markdown", "lucide-react"],
     devDependencies: ["@tailwindcss/typography"],
-    registryDependencies: [
-      "<registryBaseUrl>/utils.json",
-      "collapsible",
-      "separator",
-    ],
+    registryDependencies: ["@ncdai/utils", "collapsible", "separator"],
     files: [
       {
         path: "work-experience/work-experience.tsx",

--- a/src/registry/registry-examples.ts
+++ b/src/registry/registry-examples.ts
@@ -4,7 +4,7 @@ export const examples: Registry["items"] = [
   {
     name: "apple-hello-effect-vi-demo",
     type: "registry:example",
-    registryDependencies: ["<registryBaseUrl>/apple-hello-effect.json"],
+    registryDependencies: ["@ncdai/apple-hello-effect"],
     files: [
       {
         path: "examples/apple-hello-effect-vi-demo.tsx",
@@ -15,7 +15,7 @@ export const examples: Registry["items"] = [
   {
     name: "apple-hello-effect-en-demo",
     type: "registry:example",
-    registryDependencies: ["<registryBaseUrl>/apple-hello-effect.json"],
+    registryDependencies: ["@ncdai/apple-hello-effect"],
     files: [
       {
         path: "examples/apple-hello-effect-en-demo.tsx",
@@ -26,7 +26,7 @@ export const examples: Registry["items"] = [
   {
     name: "theme-switcher-demo",
     type: "registry:example",
-    registryDependencies: ["<registryBaseUrl>/theme-switcher.json"],
+    registryDependencies: ["@ncdai/theme-switcher"],
     files: [
       {
         path: "examples/theme-switcher-demo.tsx",
@@ -37,7 +37,7 @@ export const examples: Registry["items"] = [
   {
     name: "wheel-picker-demo",
     type: "registry:example",
-    registryDependencies: ["<registryBaseUrl>/wheel-picker.json"],
+    registryDependencies: ["@ncdai/wheel-picker"],
     files: [
       {
         path: "examples/wheel-picker-demo.tsx",
@@ -48,7 +48,7 @@ export const examples: Registry["items"] = [
   {
     name: "wheel-picker-form-demo",
     type: "registry:example",
-    registryDependencies: ["<registryBaseUrl>/wheel-picker.json", "form"],
+    registryDependencies: ["@ncdai/wheel-picker", "form"],
     files: [
       {
         path: "examples/wheel-picker-form-demo.tsx",
@@ -59,7 +59,7 @@ export const examples: Registry["items"] = [
   {
     name: "work-experience-demo",
     type: "registry:example",
-    registryDependencies: ["<registryBaseUrl>/work-experience.json"],
+    registryDependencies: ["@ncdai/work-experience"],
     files: [
       {
         path: "examples/work-experience-demo.tsx",


### PR DESCRIPTION
…f URLs

Switch from using URL-based registry dependencies to package names for improved maintainability and readability. This change simplifies the process of managing dependencies and aligns with best practices for package management.