### PR TITLE
docs(profile): update user statistics for ZaDark and React Wheel Picker

### DIFF
--- a/src/features/profile/data/experiences.ts
+++ b/src/features/profile/data/experiences.ts
@@ -78,7 +78,7 @@ In-house Project: [Quaric Website](https://quaric.com)
 
 In-house Project: [ZaDark](https://zadark.com)
 - Build and maintain ZaDark.com with Docusaurus, integrating AdSense.
-- Develop and maintain the ZaDark extension for Zalo Web on Chrome, Safari, Edge, and Firefox — with 18k+ active users via Chrome Web Store (as of Sep 2025).`,
+- Develop and maintain the ZaDark extension for Zalo Web on Chrome, Safari, Edge, and Firefox — with 20k+ active users via Chrome Web Store (as of Sep 2025).`,
         skills: [
           "Next.js",
           "Strapi",

--- a/src/features/profile/data/projects.ts
+++ b/src/features/profile/data/projects.ts
@@ -106,7 +106,7 @@ Blog Features:
     description: `ZaDark adds Dark Mode, anti-peeking, customizable fonts, backgrounds, and more to Zalo Web and PC.
 - Earned 10M+ VND in net sales from a paid Safari Extension
 - 80k+ downloads on SourceForge (awarded Community Leader badge by SourceForge)
-- 18k+ active users via Chrome Web Store (as of Sep 2025)
+- 20k+ active users via Chrome Web Store (as of Sep 2025)
 - Bronze Medal — 10th Design, Manufacturing, and Application Award 2022`,
     logo: "https://assets.chanhdai.com/images/project-logos/zadark.svg",
   },

--- a/src/features/profile/data/user.ts
+++ b/src/features/profile/data/user.ts
@@ -35,9 +35,9 @@ Hello, World! I am Chánh Đại — a Design Engineer passionate about creating
 
 With 5+ years of experience, I specialize in building high-quality web and mobile applications using Next.js, React, TypeScript, and modern front-end technologies. Beyond work, I love exploring new technologies and turning ideas into reality through personal projects.
 
-One of my key projects, [ZaDark](https://zadark.com), launched in 2022, enhances the Zalo experience on PC and Web, surpassing 80k+ downloads on [SourceForge](https://sourceforge.net/projects/zadark) and reaching 18k+ active users on the [Chrome Web Store](https://chromewebstore.google.com/detail/llfhpkkeljlgnjgkholeppfnepmjppob) (as of Sep 2025).
+One of my key projects, [ZaDark](https://zadark.com), launched in 2022, enhances the Zalo experience on PC and Web, surpassing 80k+ downloads on [SourceForge](https://sourceforge.net/projects/zadark) and reaching 20k+ active users on the [Chrome Web Store](https://chromewebstore.google.com/detail/llfhpkkeljlgnjgkholeppfnepmjppob) (as of Sep 2025).
 
-I'm also the creator of [React Wheel Picker](https://react-wheel-picker.chanhdai.com) — iOS-like wheel picker for React with smooth inertia scrolling and infinite loop support. It has earned 300+ stars on [GitHub](https://github.com/ncdai/react-wheel-picker) and was selected for [▲Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker) summer 2025 cohort.
+I'm also the creator of [React Wheel Picker](https://react-wheel-picker.chanhdai.com) — iOS-like wheel picker for React with smooth inertia scrolling and infinite loop support. It has earned 4k+ weekly downloads on [npm](https://www.npmjs.com/package/@ncdai/react-wheel-picker) and was selected for [▲Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker) summer 2025 cohort.
 
 Let's connect and collaborate!
   `,


### PR DESCRIPTION
Update active user count for ZaDark to 20k+ on Chrome Web Store. Update weekly downloads for React Wheel Picker to 4k+ on npm.