### PR TITLE
feat(analytics): add blog search event tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,8 @@ The project uses PostHog for analytics tracking. Events are defined in `src/lib/
   - Navigation: Properties `action: "navigate"`, `href`, `open_in_new_tab`
   - Copy: Properties `action: "copy"`, `text` (copied content)
   - Theme: Properties `action: "change_theme"`, `theme` ("light" | "dark" | "system")
+- `blog_search` - User searches blog posts (debounced 500ms)
+  - Properties: `query` (search text), `query_length` (query length)
 
 **Implementation Details**:
 

--- a/src/features/blog/components/post-search-input.tsx
+++ b/src/features/blog/components/post-search-input.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { XIcon } from "lucide-react";
+import { useEffect } from "react";
 
 import { Icons } from "@/components/icons";
 import {
@@ -9,11 +10,28 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from "@/components/ui/input-group";
+import { trackEvent } from "@/lib/events";
 
 import { useSearchQuery } from "../hooks/use-search-query";
 
 export function PostSearchInput() {
   const { query, setQuery } = useSearchQuery();
+
+  useEffect(() => {
+    if (query && query.length >= 2) {
+      const timeoutId = setTimeout(() => {
+        trackEvent({
+          name: "blog_search",
+          properties: {
+            query: query,
+            query_length: query.length,
+          },
+        });
+      }, 500);
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [query]);
 
   return (
     <InputGroup className="rounded-lg">

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -9,6 +9,7 @@ const eventSchema = z.object({
     "open_command_menu",
     "command_menu_search",
     "command_menu_action",
+    "blog_search",
   ]),
   properties: z
     .record(z.union([z.string(), z.number(), z.boolean(), z.null()]))


### PR DESCRIPTION
Add `blog_search` event to track user searches in blog posts. Include properties `query` and `query_length` for detailed insights. Implement debounced tracking in `PostSearchInput` component to optimize performance and avoid excessive event firing.