### PR TITLE
feat: integrate react-hotkeys-hook for keyboard shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-dom": "19.2.0",
     "react-fast-marquee": "^1.6.5",
     "react-hook-form": "^7.54.2",
+    "react-hotkeys-hook": "^5.2.1",
     "react-markdown": "^10.1.0",
     "react-medium-image-zoom": "^5.4.0",
     "react-use": "^17.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.2
         version: 7.54.2(react@19.2.0)
+      react-hotkeys-hook:
+        specifier: ^5.2.1
+        version: 5.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.5)(react@19.2.0)
@@ -5250,6 +5253,12 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-hotkeys-hook@5.2.1:
+    resolution: {integrity: sha512-xbKh6zJxd/vJHT4Bw4+0pBD662Fk20V+VFhLqciCg+manTVO4qlqRqiwFOYelfHN9dBvWj9vxaPkSS26ZSIJGg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -11980,6 +11989,11 @@ snapshots:
   react-hook-form@7.54.2(react@19.2.0):
     dependencies:
       react: 19.2.0
+
+  react-hotkeys-hook@5.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   react-is@16.13.1: {}
 

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -20,6 +20,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useTheme } from "next-themes";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { toast } from "sonner";
 
 import {
@@ -131,43 +132,22 @@ export function CommandMenu({ posts }: { posts: Post[] }) {
 
   const playClick = useSound("/audio/ui-sounds/click.wav");
 
-  useEffect(() => {
-    const abortController = new AbortController();
-    const { signal } = abortController;
+  useHotkeys("mod+k, slash", (e) => {
+    e.preventDefault();
 
-    document.addEventListener(
-      "keydown",
-      (e: KeyboardEvent) => {
-        if ((e.key === "k" && (e.metaKey || e.ctrlKey)) || e.key === "/") {
-          if (
-            (e.target instanceof HTMLElement && e.target.isContentEditable) ||
-            e.target instanceof HTMLInputElement ||
-            e.target instanceof HTMLTextAreaElement ||
-            e.target instanceof HTMLSelectElement
-          ) {
-            return;
-          }
-
-          e.preventDefault();
-          setOpen((open) => {
-            if (!open) {
-              trackEvent({
-                name: "open_command_menu",
-                properties: {
-                  method: "keyboard",
-                  key: e.key === "/" ? "/" : e.metaKey ? "cmd+k" : "ctrl+k",
-                },
-              });
-            }
-            return !open;
-          });
-        }
-      },
-      { signal }
-    );
-
-    return () => abortController.abort();
-  }, []);
+    setOpen((open) => {
+      if (!open) {
+        trackEvent({
+          name: "open_command_menu",
+          properties: {
+            method: "keyboard",
+            key: e.key === "/" ? "/" : e.metaKey ? "cmd+k" : "ctrl+k",
+          },
+        });
+      }
+      return !open;
+    });
+  });
 
   const handleOpenLink = useCallback(
     (href: string, openInNewTab = false) => {

--- a/src/features/blog/components/post-keyboard-shortcuts.tsx
+++ b/src/features/blog/components/post-keyboard-shortcuts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 
 import type { Post } from "@/features/blog/types/post";
 
@@ -22,38 +22,8 @@ export function PostKeyboardShortcuts({
     }
   };
 
-  useEffect(() => {
-    const abortController = new AbortController();
-    const { signal } = abortController;
-
-    document.addEventListener(
-      "keydown",
-      (e: KeyboardEvent) => {
-        if (["ArrowRight", "ArrowLeft"].includes(e.key)) {
-          if (
-            (e.target instanceof HTMLElement && e.target.isContentEditable) ||
-            e.target instanceof HTMLInputElement ||
-            e.target instanceof HTMLTextAreaElement ||
-            e.target instanceof HTMLSelectElement
-          ) {
-            return;
-          }
-
-          e.preventDefault();
-
-          if (e.key === "ArrowRight") {
-            navigate(next);
-          } else {
-            navigate(previous);
-          }
-        }
-      },
-      { signal }
-    );
-
-    return () => abortController.abort();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  useHotkeys("ArrowRight", () => navigate(next));
+  useHotkeys("ArrowLeft", () => navigate(previous));
 
   return null;
 }

--- a/src/features/blog/components/post-search-input.tsx
+++ b/src/features/blog/components/post-search-input.tsx
@@ -2,6 +2,7 @@
 
 import { XIcon } from "lucide-react";
 import { useEffect } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 
 import { Icons } from "@/components/icons";
 import {
@@ -16,6 +17,8 @@ import { useSearchQuery } from "../hooks/use-search-query";
 
 export function PostSearchInput() {
   const { query, setQuery } = useSearchQuery();
+
+  useHotkeys("esc", () => setQuery(null), { enableOnFormTags: true });
 
   useEffect(() => {
     if (query && query.length >= 2) {


### PR DESCRIPTION
Add react-hotkeys-hook to package.json to simplify keyboard shortcut management. Replace manual event listeners with useHotkeys hook in command-menu.tsx, post-keyboard-shortcuts.tsx, and post-search-input.tsx for improved readability and maintainability. This change reduces boilerplate code and leverages a well-tested library for handling keyboard events.