### PR TITLE
feat(blog): add tooltips with keyboard shortcuts for navigation buttons

### DIFF
--- a/src/app/(app)/(docs)/blog/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/blog/[slug]/page.tsx
@@ -9,6 +9,12 @@ import type { BlogPosting as PageSchema, WithContext } from "schema-dts";
 import { InlineTOC } from "@/components/inline-toc";
 import { MDX } from "@/components/mdx";
 import { Button } from "@/components/ui/button";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Prose } from "@/components/ui/typography";
 import { SITE_INFO } from "@/config/site";
 import { PostKeyboardShortcuts } from "@/features/blog/components/post-keyboard-shortcuts";
@@ -144,21 +150,51 @@ export default async function Page({
           <PostShareMenu url={getPostUrl(post)} />
 
           {previous && (
-            <Button variant="secondary" size="icon-sm" asChild>
-              <Link href={`/blog/${previous.slug}`}>
-                <ArrowLeftIcon />
-                <span className="sr-only">Previous</span>
-              </Link>
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="secondary" size="icon-sm" asChild>
+                  <Link href={`/blog/${previous.slug}`}>
+                    <ArrowLeftIcon />
+                    <span className="sr-only">Previous</span>
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+
+              <TooltipContent className="pr-2 pl-3">
+                <div className="flex items-center gap-3">
+                  Previous Post
+                  <KbdGroup>
+                    <Kbd>
+                      <ArrowLeftIcon />
+                    </Kbd>
+                  </KbdGroup>
+                </div>
+              </TooltipContent>
+            </Tooltip>
           )}
 
           {next && (
-            <Button variant="secondary" size="icon-sm" asChild>
-              <Link href={`/blog/${next.slug}`}>
-                <span className="sr-only">Next</span>
-                <ArrowRightIcon />
-              </Link>
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="secondary" size="icon-sm" asChild>
+                  <Link href={`/blog/${next.slug}`}>
+                    <span className="sr-only">Next</span>
+                    <ArrowRightIcon />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+
+              <TooltipContent className="pr-2 pl-3">
+                <div className="flex items-center gap-3">
+                  Next Post
+                  <KbdGroup>
+                    <Kbd>
+                      <ArrowRightIcon />
+                    </Kbd>
+                  </KbdGroup>
+                </div>
+              </TooltipContent>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/src/app/(app)/(docs)/components/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/components/[slug]/page.tsx
@@ -9,6 +9,12 @@ import type { BlogPosting as PageSchema, WithContext } from "schema-dts";
 import { InlineTOC } from "@/components/inline-toc";
 import { MDX } from "@/components/mdx";
 import { Button } from "@/components/ui/button";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Prose } from "@/components/ui/typography";
 import { SITE_INFO } from "@/config/site";
 import { PostKeyboardShortcuts } from "@/features/blog/components/post-keyboard-shortcuts";
@@ -152,21 +158,51 @@ export default async function Page({
           <PostShareMenu url={`/components/${post.slug}`} />
 
           {previous && (
-            <Button variant="secondary" size="icon-sm" asChild>
-              <Link href={`/components/${previous.slug}`}>
-                <ArrowLeftIcon />
-                <span className="sr-only">Previous</span>
-              </Link>
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="secondary" size="icon-sm" asChild>
+                  <Link href={`/components/${previous.slug}`}>
+                    <ArrowLeftIcon />
+                    <span className="sr-only">Previous</span>
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+
+              <TooltipContent className="pr-2 pl-3">
+                <div className="flex items-center gap-3">
+                  Previous Component
+                  <KbdGroup>
+                    <Kbd>
+                      <ArrowLeftIcon />
+                    </Kbd>
+                  </KbdGroup>
+                </div>
+              </TooltipContent>
+            </Tooltip>
           )}
 
           {next && (
-            <Button variant="secondary" size="icon-sm" asChild>
-              <Link href={`/components/${next.slug}`}>
-                <span className="sr-only">Next</span>
-                <ArrowRightIcon />
-              </Link>
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="secondary" size="icon-sm" asChild>
+                  <Link href={`/components/${next.slug}`}>
+                    <span className="sr-only">Next</span>
+                    <ArrowRightIcon />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+
+              <TooltipContent className="pr-2 pl-3">
+                <div className="flex items-center gap-3">
+                  Next Component
+                  <KbdGroup>
+                    <Kbd>
+                      <ArrowRightIcon />
+                    </Kbd>
+                  </KbdGroup>
+                </div>
+              </TooltipContent>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -36,13 +36,13 @@ import type { Post } from "@/features/blog/types/post";
 import { SOCIAL_LINKS } from "@/features/portfolio/data/social-links";
 import { useSound } from "@/hooks/use-sound";
 import { trackEvent } from "@/lib/events";
-import { cn } from "@/lib/utils";
 import { copyText } from "@/utils/copy";
 
 import { ChanhDaiMark, getMarkSVG } from "./chanhdai-mark";
 import { getWordmarkSVG } from "./chanhdai-wordmark";
 import { ComponentIcon, Icons } from "./icons";
 import { Button } from "./ui/button";
+import { Kbd, KbdGroup } from "./ui/kbd";
 import { Separator } from "./ui/separator";
 
 type CommandLinkItem = {
@@ -244,12 +244,15 @@ export function CommandMenu({ posts }: { posts: Post[] }) {
           Search
         </span>
 
-        <CommandMenuKbd className="hidden tracking-wider sm:in-[.os-macos_&]:flex">
-          ⌘K
-        </CommandMenuKbd>
-        <CommandMenuKbd className="hidden sm:not-[.os-macos_&]:flex">
-          Ctrl K
-        </CommandMenuKbd>
+        <KbdGroup className="hidden sm:in-[.os-macos_&]:flex">
+          <Kbd className="w-5 min-w-5">⌘</Kbd>
+          <Kbd className="w-5 min-w-5">K</Kbd>
+        </KbdGroup>
+
+        <KbdGroup className="hidden sm:not-[.os-macos_&]:flex">
+          <Kbd>Ctrl</Kbd>
+          <Kbd className="w-5 min-w-5">K</Kbd>
+        </KbdGroup>
       </Button>
 
       <CommandDialog open={open} onOpenChange={setOpen}>
@@ -502,30 +505,18 @@ function CommandMenuFooter() {
 
         <div className="flex shrink-0 items-center gap-2">
           <span>{ENTER_ACTION_LABELS[selectedCommandKind]}</span>
-          <CommandMenuKbd>
+          <Kbd>
             <CornerDownLeftIcon />
-          </CommandMenuKbd>
+          </Kbd>
           <Separator
             orientation="vertical"
             className="data-[orientation=vertical]:h-4"
           />
           <span className="text-muted-foreground">Exit</span>
-          <CommandMenuKbd>Esc</CommandMenuKbd>
+          <Kbd>Esc</Kbd>
         </div>
       </div>
     </>
-  );
-}
-
-function CommandMenuKbd({ className, ...props }: React.ComponentProps<"kbd">) {
-  return (
-    <kbd
-      className={cn(
-        "pointer-events-none flex h-5 min-w-6 items-center justify-center gap-1 rounded-sm bg-black/5 px-1 font-sans text-[13px] font-normal text-muted-foreground shadow-[inset_0_-1px_2px] shadow-black/10 select-none dark:bg-white/10 dark:shadow-white/10 dark:text-shadow-xs [&_svg:not([class*='size-'])]:size-3",
-        className
-      )}
-      {...props}
-    />
   );
 }
 

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-fit min-w-6 items-center justify-center gap-1 rounded-sm px-1 font-sans text-[13px] font-normal text-muted-foreground select-none",
+        "bg-black/5 shadow-[inset_0_-1px_2px] shadow-black/10 dark:bg-white/10 dark:shadow-white/10",
+        "[&_svg:not([class*='size-'])]:size-3",
+        "in-data-[slot=tooltip-content]:bg-white/20 in-data-[slot=tooltip-content]:text-background in-data-[slot=tooltip-content]:shadow-white/20 dark:in-data-[slot=tooltip-content]:bg-black/10 dark:in-data-[slot=tooltip-content]:shadow-black/10 dark:in-data-[slot=tooltip-content]:text-shadow-xs",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+export { Kbd, KbdGroup };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -45,7 +45,7 @@ const TooltipContent = ({
       data-slot="tooltip-content"
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-w-sm animate-in rounded-lg bg-primary px-4 py-2 font-mono text-sm text-primary-foreground fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+        "z-50 max-w-sm animate-in rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
         className
       )}
       {...props}


### PR DESCRIPTION
Add tooltips to previous and next buttons in blog and component pages to enhance user experience by displaying keyboard shortcuts.

refactor(command-menu): replace CommandMenuKbd with Kbd and KbdGroup

Create new Kbd and KbdGroup components to standardize keyboard shortcut display across the application, improving code maintainability.

style(tooltip): remove unused font-mono class from TooltipContent

Simplify TooltipContent styling by removing unnecessary font-mono class to ensure consistent text styling.