### PR TITLE
fix: add rel to block viewer new-tab link

### DIFF
--- a/src/components/block-viewer.tsx
+++ b/src/components/block-viewer.tsx
@@ -223,7 +223,11 @@ function BlockViewerToolbar() {
             size="icon-xs"
             asChild
           >
-            <a href={`/view/${item.name}`} target="_blank">
+            <a
+              href={`/view/${item.name}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <Icons.fullScreen className="size-4" />
               <span className="sr-only">Open in New Tab</span>
             </a>


### PR DESCRIPTION
## Summary

This PR adds the missing `rel` attribute to the block viewer link that opens a preview in a new tab.

The link already used `target="_blank"`, but it did not include `rel="noopener noreferrer"`. This aligns it with the safer pattern already used elsewhere in the codebase.

## Changes

- add `rel="noopener noreferrer"` to the new-tab link in `BlockViewerToolbar`

## Verification

- ran `pnpm check-types`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for external links by preventing newly opened pages from accessing the opener window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->