### PR TITLE
fix: separate blog and component doc surfaces

### DIFF
--- a/src/app/(app)/(docs)/blog/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/blog/[slug]/page.tsx
@@ -21,7 +21,7 @@ import { LLMCopyButtonWithViewOptions } from "@/features/blog/components/post-pa
 import { PostShareMenu } from "@/features/blog/components/post-share-menu"
 import {
   findNeighbour,
-  getAllDocs,
+  getBlogDocs,
   getDocBySlug,
 } from "@/features/doc/data/documents"
 import type { Doc } from "@/features/doc/types/document"
@@ -33,7 +33,7 @@ export const dynamic = "force-static"
 export const dynamicParams = false
 
 export async function generateStaticParams() {
-  const docs = getAllDocs()
+  const docs = getBlogDocs()
   return docs.map((doc) => ({ slug: doc.slug }))
 }
 
@@ -45,7 +45,7 @@ export async function generateMetadata({
   const slug = (await params).slug
   const doc = getDocBySlug(slug)
 
-  if (!doc) {
+  if (!doc || doc.metadata.category === "components") {
     return notFound()
   }
 
@@ -114,13 +114,13 @@ export default async function Page({
   const slug = (await params).slug
   const doc = getDocBySlug(slug)
 
-  if (!doc) {
+  if (!doc || doc.metadata.category === "components") {
     notFound()
   }
 
   const toc = getTableOfContents(doc.content)
 
-  const allDocs = getAllDocs()
+  const allDocs = getBlogDocs()
   const { previous, next } = findNeighbour(allDocs, slug)
 
   return (

--- a/src/app/(app)/(docs)/blog/page.tsx
+++ b/src/app/(app)/(docs)/blog/page.tsx
@@ -5,7 +5,7 @@ import { SITE_INFO, X_USERNAME } from "@/config/site"
 import { PostList } from "@/features/blog/components/post-list"
 import { PostListWithSearch } from "@/features/blog/components/post-list-with-search"
 import { PostSearchInput } from "@/features/blog/components/post-search-input"
-import { getAllDocs } from "@/features/doc/data/documents"
+import { getBlogDocs } from "@/features/doc/data/documents"
 
 export const metadata: Metadata = {
   title: "Blog",
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
 }
 
 export default function Page() {
-  const allPosts = getAllDocs()
+  const allPosts = getBlogDocs()
 
   return (
     <div className="min-h-svh">

--- a/src/app/(app)/(docs)/blog/rss/route.ts
+++ b/src/app/(app)/(docs)/blog/rss/route.ts
@@ -1,11 +1,11 @@
 import { SITE_INFO } from "@/config/site"
-import { getAllDocs } from "@/features/doc/data/documents"
+import { getBlogDocs } from "@/features/doc/data/documents"
 
 export const revalidate = false
 export const dynamic = "force-static"
 
 export function GET() {
-  const allPosts = getAllDocs()
+  const allPosts = getBlogDocs()
 
   const itemsXml = allPosts
     .map(

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,10 +1,10 @@
 import type { MetadataRoute } from "next"
 
 import { SITE_INFO } from "@/config/site"
-import { getAllDocs, getDocsByCategory } from "@/features/doc/data/documents"
+import { getBlogDocs, getDocsByCategory } from "@/features/doc/data/documents"
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const posts = getAllDocs().map((post) => ({
+  const posts = getBlogDocs().map((post) => ({
     url: `${SITE_INFO.url}/blog/${post.slug}`,
     lastModified: new Date(post.metadata.updatedAt).toISOString(),
   }))

--- a/src/features/doc/data/documents.ts
+++ b/src/features/doc/data/documents.ts
@@ -61,6 +61,10 @@ export function getDocsByCategory(category: string) {
   return getAllDocs().filter((doc) => doc.metadata?.category === category)
 }
 
+export function getBlogDocs() {
+  return getAllDocs().filter((doc) => doc.metadata.category !== "components")
+}
+
 export function findNeighbour(docs: Doc[], slug: string) {
   const len = docs.length
 

--- a/src/features/doc/data/documents.ts
+++ b/src/features/doc/data/documents.ts
@@ -61,7 +61,7 @@ export function getDocsByCategory(category: string) {
   return getAllDocs().filter((doc) => doc.metadata?.category === category)
 }
 
-export function getBlogDocs() {
+export function getBlogDocs(): Doc[] {
   return getAllDocs().filter((doc) => doc.metadata.category !== "components")
 }
 

--- a/src/features/portfolio/components/blog.tsx
+++ b/src/features/portfolio/components/blog.tsx
@@ -3,12 +3,12 @@ import Link from "next/link"
 
 import { Button } from "@/components/base/ui/button"
 import { PostItem } from "@/features/blog/components/post-item"
-import { getAllDocs } from "@/features/doc/data/documents"
+import { getBlogDocs } from "@/features/doc/data/documents"
 
 import { Panel, PanelHeader, PanelTitle, PanelTitleSup } from "./panel"
 
 export function Blog() {
-  const allPosts = getAllDocs()
+  const allPosts = getBlogDocs()
 
   return (
     <Panel id="blog">


### PR DESCRIPTION
## Summary

This PR separates blog-only surfaces from component documentation surfaces.

Several blog entry points were sourcing data from `getAllDocs()`, which includes both uncategorized blog posts and docs with `category: "components"`. As a result, component docs could leak into the blog index, the homepage blog panel, the blog RSS feed, and blog URLs in the sitemap.

## Changes

- add `getBlogDocs()` to return only non-component docs
- use `getBlogDocs()` for the blog index
- use `getBlogDocs()` for blog RSS generation
- use `getBlogDocs()` for the homepage blog panel
- restrict blog static params and prev/next navigation to blog docs only
- return `notFound()` for component docs under `/blog/[slug]`
- use `getBlogDocs()` for blog URLs in the sitemap

## Verification

- ran `pnpm check-types`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Blog content is now sourced and filtered separately from other docs, improving separation across blog pages, RSS, sitemap, and portfolio listings.
* **Bug Fixes**
  * Tightened not-found handling for certain doc categories and updated previous/next post navigation to reflect the filtered blog dataset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->