### PR TITLE
feat(theme-toggle-effect): add cleanup effect for theme toggle styles

### DIFF
--- a/src/registry/examples/theme-toggle-effect-demo/theme-toggle-effect-selector.tsx
+++ b/src/registry/examples/theme-toggle-effect-demo/theme-toggle-effect-selector.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useLayoutEffect, useState } from "react"
+import { useEffect, useLayoutEffect, useState } from "react"
 
 import {
   Select,
@@ -22,6 +22,12 @@ export function ThemeToggleEffectSelector() {
   useLayoutEffect(() => {
     addEffectStyle(document, EFFECTS[effectName]?.css || "", EFFECT_STYLE_ID)
   }, [effectName])
+
+  useEffect(() => {
+    return () => {
+      removeEffectStyle(document, EFFECT_STYLE_ID)
+    }
+  }, [])
 
   return (
     <Select
@@ -46,6 +52,10 @@ export function ThemeToggleEffectSelector() {
       </SelectContent>
     </Select>
   )
+}
+
+function removeEffectStyle(doc: Document, styleId: string) {
+  doc.getElementById(styleId)?.remove()
 }
 
 function addEffectStyle(doc: Document, cssText: string, styleId: string) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed theme-toggle-effect-selector to properly clean up injected styles when the component is removed, preventing style elements from persisting in the DOM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->