### PR TITLE
feat(command-menu, theme-toggle): add sound effect on theme change

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -36,8 +36,10 @@ import {
 } from "@/components/ui/command"
 import type { DocPreview } from "@/features/doc/types/document"
 import { SOCIAL_LINKS } from "@/features/portfolio/data/social-links"
+import { useSound } from "@/hooks/soundcn/use-sound"
 import { useDuckFollowerVisibility } from "@/hooks/use-duck-follower-visibility"
 import { trackEvent } from "@/lib/events"
+import { clickSoftSound } from "@/lib/soundcn/click-soft"
 import { copyToClipboardWithEvent } from "@/utils/copy"
 
 import { ChanhDaiMark, getMarkSVG } from "./chanhdai-mark"
@@ -185,6 +187,8 @@ export function CommandMenu({
 
   const [, setIsDuckFollowerVisible] = useDuckFollowerVisibility()
 
+  const [playClick] = useSound(clickSoftSound, { volume: 0.2 })
+
   useHotkeys(
     "mod+k, slash",
     (e) => {
@@ -242,6 +246,7 @@ export function CommandMenu({
 
   const createThemeHandler = useCallback(
     (theme: "light" | "dark" | "system") => () => {
+      playClick()
       setOpen(false)
 
       trackEvent({
@@ -254,7 +259,7 @@ export function CommandMenu({
 
       setTheme(theme)
     },
-    [setTheme]
+    [playClick, setTheme]
   )
 
   const handleToggleDuckFollower = useCallback(() => {

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -21,8 +21,8 @@ export function ThemeToggle() {
 
   const [play] = useSound(clickSoftSound, { volume: 0.2 })
 
-  const switchTheme = (sound = true) => {
-    if (sound) play()
+  const switchTheme = () => {
+    play()
     setTheme(resolvedTheme === "dark" ? "light" : "dark")
     setMetaColor(
       resolvedTheme === "dark"
@@ -31,7 +31,7 @@ export function ThemeToggle() {
     )
   }
 
-  useHotkeys("d", () => switchTheme(false))
+  useHotkeys("d", () => switchTheme())
 
   return (
     <Tooltip>


### PR DESCRIPTION
Add a soft click sound effect when changing themes to enhance user feedback. Utilize the useSound hook to play the sound with a set volume. Remove the option to disable sound in theme-toggle to ensure consistent auditory feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Audio feedback now plays when switching themes. Sound effects are triggered when selecting theme options from the command menu or using keyboard shortcuts, providing auditory confirmation of user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->