### PR TITLE
feat(github-contributions): add environment variable for API URL

### DIFF
--- a/public/r/github-contributions.json
+++ b/public/r/github-contributions.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "src/registry/components/github-contributions/lib/get-cached-contributions.ts",
-      "content": "import { unstable_cache } from \"next/cache\"\n\nimport type { Activity } from \"@/registry/components/contribution-graph\"\n\ntype GitHubContributionsResponse = {\n  contributions: Activity[]\n}\n\nexport const getCachedContributions = unstable_cache(\n  async (username: string) => {\n    const res = await fetch(\n      `https://github-contributions-api.jogruber.de/v4/${username}?y=last`\n    )\n    const data = (await res.json()) as GitHubContributionsResponse\n    return data.contributions\n  },\n  [\"github-contributions\"],\n  { revalidate: 86400 } // Cache for 1 day (86400 seconds)\n)\n",
+      "content": "import { unstable_cache } from \"next/cache\"\n\nimport type { Activity } from \"@/registry/components/contribution-graph\"\n\ntype GitHubContributionsResponse = {\n  contributions: Activity[]\n}\n\nexport const getCachedContributions = unstable_cache(\n  async (username: string) => {\n    const res = await fetch(\n      `${process.env.GITHUB_CONTRIBUTIONS_API_URL || `https://github-contributions-api.jogruber.de`}/v4/${username}?y=last`\n    )\n    const data = (await res.json()) as GitHubContributionsResponse\n    return data.contributions\n  },\n  [\"github-contributions\"],\n  { revalidate: 86400 } // Cache for 1 day (86400 seconds)\n)\n",
       "type": "registry:lib"
     }
   ],

--- a/src/registry/components/github-contributions/lib/get-cached-contributions.ts
+++ b/src/registry/components/github-contributions/lib/get-cached-contributions.ts
@@ -9,7 +9,7 @@ type GitHubContributionsResponse = {
 export const getCachedContributions = unstable_cache(
   async (username: string) => {
     const res = await fetch(
-      `https://github-contributions-api.jogruber.de/v4/${username}?y=last`
+      `${process.env.GITHUB_CONTRIBUTIONS_API_URL || `https://github-contributions-api.jogruber.de`}/v4/${username}?y=last`
     )
     const data = (await res.json()) as GitHubContributionsResponse
     return data.contributions


### PR DESCRIPTION
Allow configuration of the GitHub contributions API URL via process.env.GITHUB_CONTRIBUTIONS_API_URL to enable flexibility in changing the API endpoint without modifying the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub contributions API endpoint configuration to support environment-based customization with a fallback to the default provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->