### PR TITLE
feat(registry): add new theme toggle effects "triangle" and "triangle…

### DIFF
--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -876,6 +876,74 @@
       "files": []
     },
     {
+      "name": "theme-toggle-effect-triangle",
+      "cssVars": {
+        "theme": {
+          "expo-out": "linear(0 0%, 0.1684 2.66%, 0.3165 5.49%, 0.446 8.52%, 0.5581 11.78%, 0.6535 15.29%, 0.7341 19.11%, 0.8011 23.3%, 0.8557 27.93%, 0.8962 32.68%, 0.9283 38.01%, 0.9529 44.08%, 0.9711 51.14%, 0.9833 59.06%, 0.9915 68.74%, 1 100%)"
+        }
+      },
+      "css": {
+        "@layer base": {
+          "::view-transition-group(root)": {
+            "animation-timing-function": "var(--expo-out)"
+          },
+          "::view-transition-old(root),.dark::view-transition-old(root)": {
+            "animation": "none",
+            "animation-fill-mode": "both",
+            "z-index": "-1"
+          },
+          "::view-transition-new(root)": {
+            "mask": "url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 40 40\"><path d=\"m20 0 20 35H0z\" fill=\"white\"/></svg>') center / 0 no-repeat",
+            "animation": "scale 0.7s",
+            "animation-fill-mode": "both"
+          },
+          "@keyframes scale": {
+            "to": {
+              "mask-size": "300vmax"
+            }
+          }
+        }
+      },
+      "docs": "https://chanhdai.com/components/theme-toggle-effect",
+      "type": "registry:style",
+      "author": "ncdai <dai@chanhdai.com>",
+      "files": []
+    },
+    {
+      "name": "theme-toggle-effect-triangle-blur",
+      "cssVars": {
+        "theme": {
+          "expo-out": "linear(0 0%, 0.1684 2.66%, 0.3165 5.49%, 0.446 8.52%, 0.5581 11.78%, 0.6535 15.29%, 0.7341 19.11%, 0.8011 23.3%, 0.8557 27.93%, 0.8962 32.68%, 0.9283 38.01%, 0.9529 44.08%, 0.9711 51.14%, 0.9833 59.06%, 0.9915 68.74%, 1 100%)"
+        }
+      },
+      "css": {
+        "@layer base": {
+          "::view-transition-group(root)": {
+            "animation-timing-function": "var(--expo-out)"
+          },
+          "::view-transition-old(root),.dark::view-transition-old(root)": {
+            "animation": "none",
+            "animation-fill-mode": "both",
+            "z-index": "-1"
+          },
+          "::view-transition-new(root)": {
+            "mask": "url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 40 40\"><path d=\"m20 0 20 35H0z\" fill=\"white\" filter=\"url(%23blur)\"/><defs><filter id=\"blur\"><feGaussianBlur stdDeviation=\"1\"/></filter></defs></svg>') center / 0 no-repeat",
+            "animation": "scale 0.7s",
+            "animation-fill-mode": "both"
+          },
+          "@keyframes scale": {
+            "to": {
+              "mask-size": "300vmax"
+            }
+          }
+        }
+      },
+      "docs": "https://chanhdai.com/components/theme-toggle-effect",
+      "type": "registry:style",
+      "author": "ncdai <dai@chanhdai.com>",
+      "files": []
+    },
+    {
       "name": "theme-toggle-effect-circle",
       "cssVars": {
         "theme": {

--- a/public/r/theme-toggle-effect-triangle-blur.json
+++ b/public/r/theme-toggle-effect-triangle-blur.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "theme-toggle-effect-triangle-blur",
+  "author": "ncdai <dai@chanhdai.com>",
+  "files": [],
+  "cssVars": {
+    "theme": {
+      "expo-out": "linear(0 0%, 0.1684 2.66%, 0.3165 5.49%, 0.446 8.52%, 0.5581 11.78%, 0.6535 15.29%, 0.7341 19.11%, 0.8011 23.3%, 0.8557 27.93%, 0.8962 32.68%, 0.9283 38.01%, 0.9529 44.08%, 0.9711 51.14%, 0.9833 59.06%, 0.9915 68.74%, 1 100%)"
+    }
+  },
+  "css": {
+    "@layer base": {
+      "::view-transition-group(root)": {
+        "animation-timing-function": "var(--expo-out)"
+      },
+      "::view-transition-old(root),.dark::view-transition-old(root)": {
+        "animation": "none",
+        "animation-fill-mode": "both",
+        "z-index": "-1"
+      },
+      "::view-transition-new(root)": {
+        "mask": "url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 40 40\"><path d=\"m20 0 20 35H0z\" fill=\"white\" filter=\"url(%23blur)\"/><defs><filter id=\"blur\"><feGaussianBlur stdDeviation=\"1\"/></filter></defs></svg>') center / 0 no-repeat",
+        "animation": "scale 0.7s",
+        "animation-fill-mode": "both"
+      },
+      "@keyframes scale": {
+        "to": {
+          "mask-size": "300vmax"
+        }
+      }
+    }
+  },
+  "docs": "https://chanhdai.com/components/theme-toggle-effect",
+  "type": "registry:style"
+}

--- a/public/r/theme-toggle-effect-triangle.json
+++ b/public/r/theme-toggle-effect-triangle.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "theme-toggle-effect-triangle",
+  "author": "ncdai <dai@chanhdai.com>",
+  "files": [],
+  "cssVars": {
+    "theme": {
+      "expo-out": "linear(0 0%, 0.1684 2.66%, 0.3165 5.49%, 0.446 8.52%, 0.5581 11.78%, 0.6535 15.29%, 0.7341 19.11%, 0.8011 23.3%, 0.8557 27.93%, 0.8962 32.68%, 0.9283 38.01%, 0.9529 44.08%, 0.9711 51.14%, 0.9833 59.06%, 0.9915 68.74%, 1 100%)"
+    }
+  },
+  "css": {
+    "@layer base": {
+      "::view-transition-group(root)": {
+        "animation-timing-function": "var(--expo-out)"
+      },
+      "::view-transition-old(root),.dark::view-transition-old(root)": {
+        "animation": "none",
+        "animation-fill-mode": "both",
+        "z-index": "-1"
+      },
+      "::view-transition-new(root)": {
+        "mask": "url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 40 40\"><path d=\"m20 0 20 35H0z\" fill=\"white\"/></svg>') center / 0 no-repeat",
+        "animation": "scale 0.7s",
+        "animation-fill-mode": "both"
+      },
+      "@keyframes scale": {
+        "to": {
+          "mask-size": "300vmax"
+        }
+      }
+    }
+  },
+  "docs": "https://chanhdai.com/components/theme-toggle-effect",
+  "type": "registry:style"
+}

--- a/src/__registry__/registry.autogenerated.json
+++ b/src/__registry__/registry.autogenerated.json
@@ -876,6 +876,74 @@
       "files": []
     },
     {
+      "name": "theme-toggle-effect-triangle",
+      "cssVars": {
+        "theme": {
+          "expo-out": "linear(0 0%, 0.1684 2.66%, 0.3165 5.49%, 0.446 8.52%, 0.5581 11.78%, 0.6535 15.29%, 0.7341 19.11%, 0.8011 23.3%, 0.8557 27.93%, 0.8962 32.68%, 0.9283 38.01%, 0.9529 44.08%, 0.9711 51.14%, 0.9833 59.06%, 0.9915 68.74%, 1 100%)"
+        }
+      },
+      "css": {
+        "@layer base": {
+          "::view-transition-group(root)": {
+            "animation-timing-function": "var(--expo-out)"
+          },
+          "::view-transition-old(root),.dark::view-transition-old(root)": {
+            "animation": "none",
+            "animation-fill-mode": "both",
+            "z-index": "-1"
+          },
+          "::view-transition-new(root)": {
+            "mask": "url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 40 40\"><path d=\"m20 0 20 35H0z\" fill=\"white\"/></svg>') center / 0 no-repeat",
+            "animation": "scale 0.7s",
+            "animation-fill-mode": "both"
+          },
+          "@keyframes scale": {
+            "to": {
+              "mask-size": "300vmax"
+            }
+          }
+        }
+      },
+      "docs": "https://chanhdai.com/components/theme-toggle-effect",
+      "type": "registry:style",
+      "author": "ncdai <dai@chanhdai.com>",
+      "files": []
+    },
+    {
+      "name": "theme-toggle-effect-triangle-blur",
+      "cssVars": {
+        "theme": {
+          "expo-out": "linear(0 0%, 0.1684 2.66%, 0.3165 5.49%, 0.446 8.52%, 0.5581 11.78%, 0.6535 15.29%, 0.7341 19.11%, 0.8011 23.3%, 0.8557 27.93%, 0.8962 32.68%, 0.9283 38.01%, 0.9529 44.08%, 0.9711 51.14%, 0.9833 59.06%, 0.9915 68.74%, 1 100%)"
+        }
+      },
+      "css": {
+        "@layer base": {
+          "::view-transition-group(root)": {
+            "animation-timing-function": "var(--expo-out)"
+          },
+          "::view-transition-old(root),.dark::view-transition-old(root)": {
+            "animation": "none",
+            "animation-fill-mode": "both",
+            "z-index": "-1"
+          },
+          "::view-transition-new(root)": {
+            "mask": "url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 40 40\"><path d=\"m20 0 20 35H0z\" fill=\"white\" filter=\"url(%23blur)\"/><defs><filter id=\"blur\"><feGaussianBlur stdDeviation=\"1\"/></filter></defs></svg>') center / 0 no-repeat",
+            "animation": "scale 0.7s",
+            "animation-fill-mode": "both"
+          },
+          "@keyframes scale": {
+            "to": {
+              "mask-size": "300vmax"
+            }
+          }
+        }
+      },
+      "docs": "https://chanhdai.com/components/theme-toggle-effect",
+      "type": "registry:style",
+      "author": "ncdai <dai@chanhdai.com>",
+      "files": []
+    },
+    {
       "name": "theme-toggle-effect-circle",
       "cssVars": {
         "theme": {

--- a/src/features/doc/content/theme-toggle-effect.mdx
+++ b/src/features/doc/content/theme-toggle-effect.mdx
@@ -31,31 +31,43 @@ This component uses the [View Transitions API](https://developer.mozilla.org/en-
 
 <TabsContent value="cli">
 
-**Circle**
+### Triangle
+
+```bash
+npx shadcn@latest add @ncdai/theme-toggle-effect-triangle
+```
+
+### Triangle Blur
+
+```bash
+npx shadcn@latest add @ncdai/theme-toggle-effect-triangle-blur
+```
+
+### Circle
 
 ```bash
 npx shadcn@latest add @ncdai/theme-toggle-effect-circle
 ```
 
-**Circle Blur**
+### Circle Blur
 
 ```bash
 npx shadcn@latest add @ncdai/theme-toggle-effect-circle-blur
 ```
 
-**Circle Blur (Top Left)**
+### Circle Blur (Top Left)
 
 ```bash
 npx shadcn@latest add @ncdai/theme-toggle-effect-circle-blur-top-left
 ```
 
-**Polygon**
+### Polygon
 
 ```bash
 npx shadcn@latest add @ncdai/theme-toggle-effect-polygon
 ```
 
-**Polygon Gradient**
+### Polygon Gradient
 
 ```bash
 npx shadcn@latest add @ncdai/theme-toggle-effect-polygon-gradient
@@ -95,6 +107,66 @@ npx shadcn@latest add @ncdai/theme-toggle-effect-polygon-gradient
 <Step>Add the effect CSS to your global CSS</Step>
 
 Choose one effect and copy its CSS into your `globals.css`
+
+**Triangle**
+
+```css
+@layer base {
+  ::view-transition-group(root) {
+    animation-timing-function: var(--expo-out);
+  }
+
+  ::view-transition-old(root),
+  .dark::view-transition-old(root) {
+    animation: none;
+    animation-fill-mode: both;
+    z-index: -1;
+  }
+
+  ::view-transition-new(root) {
+    mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path d="m20 0 20 35H0z" fill="white"/></svg>')
+      center / 0 no-repeat;
+    animation: scale 0.7s;
+    animation-fill-mode: both;
+  }
+
+  @keyframes scale {
+    to {
+      mask-size: 300vmax;
+    }
+  }
+}
+```
+
+**Triangle Blur**
+
+```css
+@layer base {
+  ::view-transition-group(root) {
+    animation-timing-function: var(--expo-out);
+  }
+
+  ::view-transition-old(root),
+  .dark::view-transition-old(root) {
+    animation: none;
+    animation-fill-mode: both;
+    z-index: -1;
+  }
+
+  ::view-transition-new(root) {
+    mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path d="m20 0 20 35H0z" fill="white" filter="url(%23blur)"/><defs><filter id="blur"><feGaussianBlur stdDeviation="1"/></filter></defs></svg>')
+      center / 0 no-repeat;
+    animation: scale 0.7s;
+    animation-fill-mode: both;
+  }
+
+  @keyframes scale {
+    to {
+      mask-size: 300vmax;
+    }
+  }
+}
+```
 
 **Circle**
 

--- a/src/registry/examples/theme-toggle-effect-demo/theme-toggle-effect-selector.tsx
+++ b/src/registry/examples/theme-toggle-effect-demo/theme-toggle-effect-selector.tsx
@@ -71,6 +71,62 @@ function addEffectStyle(doc: Document, cssText: string, styleId: string) {
 }
 
 const EFFECTS = {
+  triangle: {
+    title: "Triangle",
+    css: `
+      ::view-transition-group(root) {
+        animation-timing-function: var(--expo-out);
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: none;
+        animation-fill-mode: both;
+        z-index: -1;
+      }
+
+      ::view-transition-new(root) {
+        mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path d="m20 0 20 35H0z" fill="white"/></svg>')
+          center / 0 no-repeat;
+        animation: scale 0.7s;
+        animation-fill-mode: both;
+      }
+
+      @keyframes scale {
+        to {
+          mask-size: 300vmax;
+        }
+      }
+    `,
+  },
+  "triangle-blur": {
+    title: "Triangle Blur",
+    css: `
+      ::view-transition-group(root) {
+        animation-timing-function: var(--expo-out);
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: none;
+        animation-fill-mode: both;
+        z-index: -1;
+      }
+
+      ::view-transition-new(root) {
+        mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path d="m20 0 20 35H0z" fill="white" filter="url(%23blur)"/><defs><filter id="blur"><feGaussianBlur stdDeviation="1"/></filter></defs></svg>')
+          center / 0 no-repeat;
+        animation: scale 0.7s;
+        animation-fill-mode: both;
+      }
+
+      @keyframes scale {
+        to {
+          mask-size: 300vmax;
+        }
+      }
+    `,
+  },
   circle: {
     title: "Circle",
     css: `

--- a/src/registry/styles/_registry.ts
+++ b/src/registry/styles/_registry.ts
@@ -22,6 +22,72 @@ export const styles: Registry["items"] = [
     },
   },
   {
+    name: "theme-toggle-effect-triangle",
+    type: "registry:style",
+    cssVars: {
+      theme: {
+        "expo-out":
+          "linear(0 0%, 0.1684 2.66%, 0.3165 5.49%, 0.446 8.52%, 0.5581 11.78%, 0.6535 15.29%, 0.7341 19.11%, 0.8011 23.3%, 0.8557 27.93%, 0.8962 32.68%, 0.9283 38.01%, 0.9529 44.08%, 0.9711 51.14%, 0.9833 59.06%, 0.9915 68.74%, 1 100%)",
+      },
+    },
+    css: {
+      "@layer base": {
+        "::view-transition-group(root)": {
+          "animation-timing-function": "var(--expo-out)",
+        },
+        "::view-transition-old(root),.dark::view-transition-old(root)": {
+          animation: "none",
+          "animation-fill-mode": "both",
+          "z-index": "-1",
+        },
+        "::view-transition-new(root)": {
+          mask: `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path d="m20 0 20 35H0z" fill="white"/></svg>') center / 0 no-repeat`,
+          animation: "scale 0.7s",
+          "animation-fill-mode": "both",
+        },
+        "@keyframes scale": {
+          to: {
+            "mask-size": "300vmax",
+          },
+        },
+      },
+    },
+    docs: "https://chanhdai.com/components/theme-toggle-effect",
+  },
+  {
+    name: "theme-toggle-effect-triangle-blur",
+    type: "registry:style",
+    cssVars: {
+      theme: {
+        "expo-out":
+          "linear(0 0%, 0.1684 2.66%, 0.3165 5.49%, 0.446 8.52%, 0.5581 11.78%, 0.6535 15.29%, 0.7341 19.11%, 0.8011 23.3%, 0.8557 27.93%, 0.8962 32.68%, 0.9283 38.01%, 0.9529 44.08%, 0.9711 51.14%, 0.9833 59.06%, 0.9915 68.74%, 1 100%)",
+      },
+    },
+    css: {
+      "@layer base": {
+        "::view-transition-group(root)": {
+          "animation-timing-function": "var(--expo-out)",
+        },
+        "::view-transition-old(root),.dark::view-transition-old(root)": {
+          animation: "none",
+          "animation-fill-mode": "both",
+          "z-index": "-1",
+        },
+        "::view-transition-new(root)": {
+          mask: `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path d="m20 0 20 35H0z" fill="white" filter="url(%23blur)"/><defs><filter id="blur"><feGaussianBlur stdDeviation="1"/></filter></defs></svg>') center / 0 no-repeat`,
+          animation: "scale 0.7s",
+          "animation-fill-mode": "both",
+        },
+        "@keyframes scale": {
+          to: {
+            "mask-size": "300vmax",
+          },
+        },
+      },
+    },
+    docs: "https://chanhdai.com/components/theme-toggle-effect",
+  },
+  {
     name: "theme-toggle-effect-circle",
     type: "registry:style",
     cssVars: {


### PR DESCRIPTION
…-blur"

Add two new theme toggle effects, "triangle" and "triangle-blur", to enhance the visual transition options available. These effects utilize the View Transitions API for smooth animations. The "triangle-blur" effect includes a Gaussian blur for added visual appeal. Update documentation and examples to include usage instructions for these new effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Triangle theme toggle effect with animated transition
  * Added Triangle Blur variant effect for enhanced visual feedback
  * Both effects now available for installation and integration

* **Documentation**
  * Updated with CLI installation instructions for new effects
  * Added manual integration guides with required configuration steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->