### PR TITLE
refactor: reorganize page sections and improve tech stack component

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -54,9 +54,6 @@ export default function Page() {
         <GitHubContributions />
         <Separator />
 
-        <Sponsors />
-        <Separator />
-
         <TechStack />
         <Separator />
 
@@ -64,6 +61,9 @@ export default function Page() {
         <Separator />
 
         <Blog />
+        <Separator />
+
+        <Sponsors />
         <Separator />
 
         <Experiences />

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -105,7 +105,7 @@ const PORTFOLIO_LINKS: CommandLinkItem[] = [
     icon: <TextInitialIcon />,
   },
   {
-    title: "Tech Stack",
+    title: "Stack",
     href: "/#stack",
     icon: <LayersIcon />,
   },

--- a/src/features/portfolio/components/tech-stack.tsx
+++ b/src/features/portfolio/components/tech-stack.tsx
@@ -9,6 +9,8 @@ import {
 import { TECH_STACK } from "../data/tech-stack"
 import { Panel, PanelContent, PanelHeader, PanelTitle } from "./panel"
 
+const ICON_SIZE = 24
+
 export function TechStack() {
   return (
     <Panel id="stack">
@@ -35,16 +37,16 @@ export function TechStack() {
                             <Image
                               src={`https://assets.chanhdai.com/images/tech-stack-icons/${tech.key}-light.svg`}
                               alt={`${tech.title} light icon`}
-                              width={32}
-                              height={32}
+                              width={ICON_SIZE}
+                              height={ICON_SIZE}
                               className="hidden [html.light_&]:block"
                               unoptimized
                             />
                             <Image
                               src={`https://assets.chanhdai.com/images/tech-stack-icons/${tech.key}-dark.svg`}
                               alt={`${tech.title} dark icon`}
-                              width={32}
-                              height={32}
+                              width={ICON_SIZE}
+                              height={ICON_SIZE}
                               className="hidden [html.dark_&]:block"
                               unoptimized
                             />
@@ -53,8 +55,8 @@ export function TechStack() {
                           <Image
                             src={`https://assets.chanhdai.com/images/tech-stack-icons/${tech.key}.svg`}
                             alt={`${tech.title} icon`}
-                            width={32}
-                            height={32}
+                            width={ICON_SIZE}
+                            height={ICON_SIZE}
                             unoptimized
                           />
                         )}


### PR DESCRIPTION
- Move Sponsors section after Blog section for better content flow
- Change "Tech Stack" to "Stack" in command menu for brevity
- Extract icon size to constant in TechStack component for maintainability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Sponsors section repositioned: now appears after Blog content in the page layout instead of after GitHub Contributions.
  * Command menu: portfolio link renamed from "Tech Stack" to "Stack".
  * Tech Stack component: icon sizing standardized with consistent dimensions for both light and dark theme variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->