### PR TITLE
refactor: update lucide-react icon imports to use non-suffixed names

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -4,22 +4,22 @@ import { useRouter } from "@bprogress/next/app"
 import { useTiks } from "@rexa-developer/tiks/react"
 import { useCommandState } from "cmdk"
 import {
-  AwardIcon,
-  BookmarkIcon,
-  BoxIcon,
-  BriefcaseBusinessIcon,
-  CircleCheckBigIcon,
-  CornerDownLeftIcon,
-  DownloadIcon,
-  FileTextIcon,
-  LayersIcon,
-  MoonStarIcon,
-  MousePointer2Icon,
+  Bookmark,
+  Box,
+  BriefcaseBusiness,
+  CircleCheckBig,
+  CornerDownLeft,
+  Crown,
+  Download,
+  FileText,
+  Layers,
+  MoonStar,
+  MousePointer2,
   RssIcon,
-  SunMediumIcon,
-  TextInitialIcon,
-  TriangleDashedIcon,
-  TypeIcon,
+  SunMedium,
+  TextInitial,
+  TriangleDashed,
+  Type,
 } from "lucide-react"
 import { useTheme } from "next-themes"
 import React, { useCallback, useEffect, useMemo, useState } from "react"
@@ -102,42 +102,42 @@ const PORTFOLIO_LINKS: CommandLinkItem[] = [
   {
     title: "About",
     href: "/#about",
-    icon: <TextInitialIcon />,
+    icon: <TextInitial />,
   },
   {
     title: "Stack",
     href: "/#stack",
-    icon: <LayersIcon />,
+    icon: <Layers />,
   },
   {
     title: "Experience",
     href: "/#experience",
-    icon: <BriefcaseBusinessIcon />,
+    icon: <BriefcaseBusiness />,
   },
   {
     title: "Projects",
     href: "/#projects",
-    icon: <BoxIcon />,
+    icon: <Box />,
   },
   {
     title: "Honors & Awards",
     href: "/#awards",
-    icon: <AwardIcon />,
+    icon: <Crown />,
   },
   {
     title: "Certifications",
     href: "/#certs",
-    icon: <CircleCheckBigIcon />,
+    icon: <CircleCheckBig />,
   },
   {
     title: "Bookmarks",
     href: "/#bookmarks",
-    icon: <BookmarkIcon />,
+    icon: <Bookmark />,
   },
   {
     title: "Download vCard",
     href: "/vcard",
-    icon: <DownloadIcon />,
+    icon: <Download />,
   },
 ]
 
@@ -152,7 +152,7 @@ const OTHER_LINK_ITEMS: CommandLinkItem[] = [
   {
     title: "llms.txt",
     href: "/llms.txt",
-    icon: <FileTextIcon />,
+    icon: <FileText />,
     openInNewTab: true,
   },
   {
@@ -380,20 +380,20 @@ export function CommandMenu({
                 )
               }}
             >
-              <TypeIcon />
+              <Type />
               Copy Logotype as SVG
             </CommandItem>
 
             <CommandItem
               onSelect={() => handleOpenLink("/blog/chanhdai-brand")}
             >
-              <TriangleDashedIcon />
+              <TriangleDashed />
               Brand Guidelines
             </CommandItem>
 
             <CommandItem asChild>
               <a href="https://assets.chanhdai.com/chanhdai-brand.zip" download>
-                <DownloadIcon />
+                <Download />
                 Download Brand Assets
               </a>
             </CommandItem>
@@ -404,14 +404,14 @@ export function CommandMenu({
               keywords={["theme"]}
               onSelect={createThemeHandler("light")}
             >
-              <SunMediumIcon />
+              <SunMedium />
               Light
             </CommandItem>
             <CommandItem
               keywords={["theme"]}
               onSelect={createThemeHandler("dark")}
             >
-              <MoonStarIcon />
+              <MoonStar />
               Dark
             </CommandItem>
             <CommandItem
@@ -425,7 +425,7 @@ export function CommandMenu({
 
           <CommandGroup heading="Interactive Features">
             <CommandItem onSelect={handleToggleDuckFollower}>
-              <MousePointer2Icon />
+              <MousePointer2 />
               Toggle Duck Follower
             </CommandItem>
           </CommandGroup>
@@ -603,7 +603,7 @@ function CommandMenuFooter() {
         <div className="flex shrink-0 items-center gap-2 max-sm:hidden">
           <span>{ENTER_ACTION_LABELS[selectedCommandKind]}</span>
           <Kbd>
-            <CornerDownLeftIcon />
+            <CornerDownLeft />
           </Kbd>
           <Separator
             orientation="vertical"

--- a/src/features/portfolio/components/awards/award-item.tsx
+++ b/src/features/portfolio/components/awards/award-item.tsx
@@ -1,5 +1,5 @@
 import { format } from "date-fns"
-import { AwardIcon, FileCheckIcon } from "lucide-react"
+import { Crown, FileCheck } from "lucide-react"
 
 import {
   Collapsible,
@@ -17,8 +17,8 @@ import {
 import { Markdown } from "@/components/markdown"
 import { Separator } from "@/components/ui/separator"
 import { Prose } from "@/components/ui/typography"
-
-import type { Award } from "../../types/awards"
+import type { Award } from "@/features/portfolio/types/awards"
+import { cn } from "@/lib/utils"
 
 export function AwardItem({
   className,
@@ -32,8 +32,13 @@ export function AwardItem({
   return (
     <Collapsible className={className} disabled={!canExpand}>
       <div className="flex items-center hover:bg-accent-muted">
-        <div className="mx-4 flex size-6 shrink-0 items-center justify-center rounded-lg border border-muted-foreground/15 bg-muted ring-1 ring-line ring-offset-1 ring-offset-background">
-          <AwardIcon className="pointer-events-none size-4 text-muted-foreground" />
+        <div
+          className={cn(
+            "mx-4 flex size-6 shrink-0 items-center justify-center rounded-lg border border-muted-foreground/15 bg-muted ring-1 ring-line ring-offset-1 ring-offset-background",
+            "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4"
+          )}
+        >
+          <Crown />
         </div>
 
         <div className="flex-1 border-l border-dashed border-line">
@@ -86,7 +91,7 @@ export function AwardItem({
                       rel="noopener"
                       aria-label="Open Reference Attachment"
                     >
-                      <FileCheckIcon className="pointer-events-none size-4" />
+                      <FileCheck className="pointer-events-none size-4" />
                     </a>
                   }
                 />


### PR DESCRIPTION
Remove 'Icon' suffix from lucide-react icon imports and update all references to use the cleaner naming convention. Also replace AwardIcon with Crown icon for better semantic representation of awards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal icon component references throughout the command menu and awards sections.

* **Style**
  * Improved styling consistency for the awards section with enhanced SVG sizing, text color, and interactive element behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->