### PR TITLE
style: remove redundant className="mt-4" from ComponentPreview compon…

### DIFF
--- a/src/features/doc/content/react-wheel-picker.mdx
+++ b/src/features/doc/content/react-wheel-picker.mdx
@@ -128,7 +128,6 @@ WheelPickerWrapper
 ### Multiple Pickers, Infinite Loop
 
 <ComponentPreview
-  className="mt-4"
   name="wheel-picker-demo"
   openInV0Url="https://chanhdai.com/r/wheel-picker.json"
 />
@@ -136,7 +135,6 @@ WheelPickerWrapper
 ### React Hook Form
 
 <ComponentPreview
-  className="mt-4"
   name="wheel-picker-form-demo"
   openInV0Url="https://chanhdai.com/r/wheel-picker.json"
 />

--- a/src/features/doc/content/slide-to-unlock.mdx
+++ b/src/features/doc/content/slide-to-unlock.mdx
@@ -140,26 +140,10 @@ SlideToUnlock
 
 ## Examples
 
-### Default
-
-<ComponentPreview
-  className="mt-4"
-  name="slide-to-unlock-demo-01"
-  remountOnThemeChange
-/>
-
 ### Custom Color
 
-<ComponentPreview
-  className="mt-4"
-  name="slide-to-unlock-demo-02"
-  remountOnThemeChange
-/>
+<ComponentPreview name="slide-to-unlock-demo-02" remountOnThemeChange />
 
 ### Custom Handle
 
-<ComponentPreview
-  className="mt-4"
-  name="slide-to-unlock-demo-03"
-  remountOnThemeChange
-/>
+<ComponentPreview name="slide-to-unlock-demo-03" remountOnThemeChange />


### PR DESCRIPTION
…ents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Adjusted styling and layout for wheel picker component previews
  * Consolidated and reorganized examples in slide-to-unlock component documentation

* **Style**
  * Removed spacing modifications from documentation component preview elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->