### PR TITLE
refactor: replace tooltip tech stack with badge-style links

### DIFF
--- a/src/features/portfolio/components/tech-stack.tsx
+++ b/src/features/portfolio/components/tech-stack.tsx
@@ -1,15 +1,7 @@
 import Image from "next/image"
 
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/base/ui/tooltip"
-
 import { TECH_STACK } from "../data/tech-stack"
 import { Panel, PanelContent, PanelHeader, PanelTitle } from "./panel"
-
-const ICON_SIZE = 24
 
 export function TechStack() {
   return (
@@ -19,54 +11,47 @@ export function TechStack() {
       </PanelHeader>
 
       <PanelContent>
-        <ul className="flex flex-wrap gap-4 select-none">
+        <ul className="flex flex-wrap gap-1.5">
           {TECH_STACK.map((tech) => {
             return (
               <li key={tech.key} className="flex">
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <a
-                        href={tech.href}
-                        target="_blank"
-                        rel="noopener"
-                        aria-label={tech.title}
-                      >
-                        {tech.theme ? (
-                          <>
-                            <Image
-                              src={`https://assets.chanhdai.com/images/tech-stack-icons/${tech.key}-light.svg`}
-                              alt={`${tech.title} light icon`}
-                              width={ICON_SIZE}
-                              height={ICON_SIZE}
-                              className="hidden [html.light_&]:block"
-                              unoptimized
-                            />
-                            <Image
-                              src={`https://assets.chanhdai.com/images/tech-stack-icons/${tech.key}-dark.svg`}
-                              alt={`${tech.title} dark icon`}
-                              width={ICON_SIZE}
-                              height={ICON_SIZE}
-                              className="hidden [html.dark_&]:block"
-                              unoptimized
-                            />
-                          </>
-                        ) : (
-                          <Image
-                            src={`https://assets.chanhdai.com/images/tech-stack-icons/${tech.key}.svg`}
-                            alt={`${tech.title} icon`}
-                            width={ICON_SIZE}
-                            height={ICON_SIZE}
-                            unoptimized
-                          />
-                        )}
-                      </a>
-                    }
-                  />
-                  <TooltipContent>
-                    <p>{tech.title}</p>
-                  </TooltipContent>
-                </Tooltip>
+                <a
+                  href={tech.href}
+                  target="_blank"
+                  rel="noopener"
+                  aria-label={tech.title}
+                  className="flex items-center gap-1.5 rounded-md border bg-zinc-50 px-1.5 py-0.5 font-mono text-xs tracking-tight text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 [&_img]:size-3.5 [&_img]:select-none"
+                >
+                  {tech.theme ? (
+                    <>
+                      <Image
+                        className="hidden [html.light_&]:block"
+                        src={`https://assets.chanhdai.com/images/tech-stack-icons/${tech.key}-light.svg`}
+                        alt={`${tech.title} light icon`}
+                        width={14}
+                        height={14}
+                        unoptimized
+                      />
+                      <Image
+                        className="hidden [html.dark_&]:block"
+                        src={`https://assets.chanhdai.com/images/tech-stack-icons/${tech.key}-dark.svg`}
+                        alt={`${tech.title} dark icon`}
+                        width={14}
+                        height={14}
+                        unoptimized
+                      />
+                    </>
+                  ) : (
+                    <Image
+                      src={`https://assets.chanhdai.com/images/tech-stack-icons/${tech.key}.svg`}
+                      alt={`${tech.title} icon`}
+                      width={14}
+                      height={14}
+                      unoptimized
+                    />
+                  )}
+                  {tech.title}
+                </a>
               </li>
             )
           })}

--- a/src/features/portfolio/data/tech-stack.ts
+++ b/src/features/portfolio/data/tech-stack.ts
@@ -19,12 +19,12 @@ export const TECH_STACK: TechStack[] = [
     href: "https://www.python.org/",
     categories: ["Language"],
   },
-  // {
-  //   key: "php",
-  //   title: "PHP",
-  //   href: "https://www.php.net/",
-  //   categories: ["Language"],
-  // },
+  {
+    key: "php",
+    title: "PHP",
+    href: "https://www.php.net/",
+    categories: ["Language"],
+  },
   {
     key: "java",
     title: "Java",
@@ -109,30 +109,11 @@ export const TECH_STACK: TechStack[] = [
     categories: ["State Management"],
   },
   {
-    key: "antd",
-    title: "Ant Design",
-    href: "https://ant.design/",
-    categories: ["Library", "UI Library"],
-  },
-  {
-    key: "react-router",
-    title: "React Router",
-    href: "https://reactrouter.com/",
-    categories: ["Library", "Navigation"],
-    theme: true,
-  },
-  {
     key: "react-navigation",
     title: "React Navigation",
     href: "https://reactnavigation.org/",
     categories: ["Library", "Navigation"],
   },
-  // {
-  //   key: "loopback",
-  //   title: "LoopBack",
-  //   href: "https://loopback.io/",
-  //   categories: ["Framework"],
-  // },
   {
     key: "laravel",
     title: "Laravel",
@@ -150,6 +131,12 @@ export const TECH_STACK: TechStack[] = [
     title: "Docker",
     href: "https://www.docker.com/",
     categories: ["Containerization"],
+  },
+  {
+    key: "postgresql",
+    title: "PostgreSQL",
+    href: "https://www.postgresql.org",
+    categories: ["Database"],
   },
   {
     key: "mysql",
@@ -177,7 +164,7 @@ export const TECH_STACK: TechStack[] = [
   },
   {
     key: "ps",
-    title: "Adobe Photoshop",
+    title: "Photoshop",
     href: "https://www.adobe.com/vn_en/products/photoshop.html",
     categories: ["Tools", "Design"],
   },


### PR DESCRIPTION
Remove tooltip wrapper and display tech names directly as styled badges with icons to improve accessibility and visual clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL to the tech stack display.

* **Updates**
  * Removed Ant Design and React Router from tech stack.
  * Enabled PHP in the tech stack.
  * Replaced tooltip hover interactions with direct clickable links for technology items.
  * Improved spacing and visual layout of tech stack section.
  * Shortened "Adobe Photoshop" label to "Photoshop."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->