### PR TITLE
feat: add thin-scrollbar style component to registry

### DIFF
--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -1138,6 +1138,30 @@
       "type": "registry:style",
       "author": "ncdai <dai@chanhdai.com>",
       "files": []
+    },
+    {
+      "name": "thin-scrollbar",
+      "css": {
+        "@layer base": {
+          "::-webkit-scrollbar": {
+            "width": "5px"
+          },
+          "::-webkit-scrollbar-track": {
+            "background": "transparent"
+          },
+          "::-webkit-scrollbar-thumb": {
+            "background": "var(--border)",
+            "border-radius": "5px"
+          },
+          "*": {
+            "scrollbar-width": "thin",
+            "scrollbar-color": "var(--border) transparent"
+          }
+        }
+      },
+      "type": "registry:style",
+      "author": "ncdai <dai@chanhdai.com>",
+      "files": []
     }
   ]
 }

--- a/public/r/thin-scrollbar.json
+++ b/public/r/thin-scrollbar.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "thin-scrollbar",
+  "author": "ncdai <dai@chanhdai.com>",
+  "files": [],
+  "css": {
+    "@layer base": {
+      "::-webkit-scrollbar": {
+        "width": "5px"
+      },
+      "::-webkit-scrollbar-track": {
+        "background": "transparent"
+      },
+      "::-webkit-scrollbar-thumb": {
+        "background": "var(--border)",
+        "border-radius": "5px"
+      },
+      "*": {
+        "scrollbar-width": "thin",
+        "scrollbar-color": "var(--border) transparent"
+      }
+    }
+  },
+  "type": "registry:style"
+}

--- a/src/__registry__/registry.autogenerated.json
+++ b/src/__registry__/registry.autogenerated.json
@@ -1138,6 +1138,30 @@
       "type": "registry:style",
       "author": "ncdai <dai@chanhdai.com>",
       "files": []
+    },
+    {
+      "name": "thin-scrollbar",
+      "css": {
+        "@layer base": {
+          "::-webkit-scrollbar": {
+            "width": "5px"
+          },
+          "::-webkit-scrollbar-track": {
+            "background": "transparent"
+          },
+          "::-webkit-scrollbar-thumb": {
+            "background": "var(--border)",
+            "border-radius": "5px"
+          },
+          "*": {
+            "scrollbar-width": "thin",
+            "scrollbar-color": "var(--border) transparent"
+          }
+        }
+      },
+      "type": "registry:style",
+      "author": "ncdai <dai@chanhdai.com>",
+      "files": []
     }
   ]
 }

--- a/src/registry/styles/_registry.ts
+++ b/src/registry/styles/_registry.ts
@@ -276,4 +276,26 @@ export const styles: Registry["items"] = [
     },
     docs: "https://chanhdai.com/components/theme-toggle-effect",
   },
+  {
+    name: "thin-scrollbar",
+    type: "registry:style",
+    css: {
+      "@layer base": {
+        "::-webkit-scrollbar": {
+          width: "5px",
+        },
+        "::-webkit-scrollbar-track": {
+          background: "transparent",
+        },
+        "::-webkit-scrollbar-thumb": {
+          background: "var(--border)",
+          "border-radius": "5px",
+        },
+        "*": {
+          "scrollbar-width": "thin",
+          "scrollbar-color": "var(--border) transparent",
+        },
+      },
+    },
+  },
 ]


### PR DESCRIPTION
Add custom scrollbar styling with 5px width, transparent track, and border-colored thumb with rounded corners for webkit browsers and thin scrollbar support for Firefox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "thin-scrollbar" style option for customizing scrollbar appearance across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->