### PR TITLE
feat: add DocSponsors component to display gold sponsors in docs

### DIFF
--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/table"
 import { Code, Heading } from "@/components/ui/typography"
 import { UTM_PARAMS } from "@/config/site"
+import { DocSponsors } from "@/features/doc/components/doc-sponsors"
 import { generator } from "@/lib/auto-type-table"
 import { rehypeAddQueryParams } from "@/lib/rehype-add-query-params"
 import {
@@ -89,6 +90,7 @@ const components: MDXRemoteProps["components"] = {
   IframeEmbed,
   FramedImage,
   Testimonial,
+  DocSponsors,
   AutoTypeTable: (props) => <AutoTypeTable {...props} generator={generator} />,
 }
 

--- a/src/features/doc/components/doc-sponsors.tsx
+++ b/src/features/doc/components/doc-sponsors.tsx
@@ -1,0 +1,37 @@
+import { UTM_PARAMS } from "@/config/site"
+import { SPONSORS } from "@/features/sponsor/data"
+import { addQueryParams } from "@/utils/url"
+
+const GOLD_SPONSORS = SPONSORS.filter((sponsor) => sponsor.tier === "gold")
+
+export function DocSponsors() {
+  return (
+    <aside
+      className="not-prose my-12 rounded-xl border border-line p-1"
+      aria-labelledby="doc-sponsors-heading"
+    >
+      <h2
+        id="doc-sponsors-heading"
+        className="px-3 pt-2 pb-3 font-heading text-sm/none font-medium tracking-tight text-muted-foreground"
+      >
+        Gold Sponsors
+      </h2>
+
+      <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+        {GOLD_SPONSORS.map((item) => (
+          <li key={item.name}>
+            <a
+              className="flex items-center justify-center rounded-lg border border-line text-foreground transition-[background-color] ease-out hover:bg-accent-muted [&_svg]:w-full [&_svg]:max-w-75 [&_svg]:shrink-0"
+              href={addQueryParams(item.url, UTM_PARAMS)}
+              target="_blank"
+              rel="noopener sponsored"
+              aria-label={`${item.name} logo`}
+            >
+              <item.logo aria-hidden />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  )
+}

--- a/src/features/doc/content/toc-minimap.mdx
+++ b/src/features/doc/content/toc-minimap.mdx
@@ -20,6 +20,8 @@ updatedAt: 2026-04-27
 - Hovering the minimap reveals a scrollable table of contents.
 - Section links update the URL hash and scroll smoothly to the target heading.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>


### PR DESCRIPTION
Create new DocSponsors component that renders gold tier sponsors in a responsive grid layout with proper accessibility attributes and UTM tracking. Integrate component into MDX system and add to table of contents minimap documentation page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gold Sponsors section to documentation pages, featuring supporter logos and direct links to sponsor websites. The section appears between the features overview and installation instructions. All sponsor links automatically open in new browser tabs, allowing easy access to explore and learn more about the organizations supporting the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->