### PR TITLE
refactor: update component preview styling and structure

### DIFF
--- a/src/components/component-preview-v2.tsx
+++ b/src/components/component-preview-v2.tsx
@@ -57,7 +57,7 @@ export function ComponentPreviewV2({
     >
       <div data-slot="preview" className="rounded-t-xl border p-2">
         {(canReplay || openInV0Url) && (
-          <div data-slot="buttons" className="mb-2 flex justify-end gap-0">
+          <div data-slot="buttons" className="mb-2 flex justify-end">
             {canReplay && (
               <Tooltip>
                 <TooltipTrigger
@@ -66,6 +66,7 @@ export function ComponentPreviewV2({
                       className="border-none"
                       variant="ghost"
                       size="icon-sm"
+                      aria-label="Replay"
                       onClick={() => setReplay((v) => v + 1)}
                     >
                       <RepeatIcon />

--- a/src/components/component-preview.tsx
+++ b/src/components/component-preview.tsx
@@ -1,16 +1,22 @@
 "use client"
 
-import { CodeXmlIcon, EyeIcon, RepeatIcon } from "lucide-react"
+import { RepeatIcon } from "lucide-react"
 import { useTheme } from "next-themes"
 import React, { useMemo, useState } from "react"
 
 import { Index } from "@/__registry__/index"
+import {
+  Tabs,
+  TabsContent,
+  TabsIndicator,
+  TabsList,
+  TabsTrigger,
+} from "@/components/base/ui/tabs"
 import { cn } from "@/lib/utils"
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "./base/ui/tooltip"
 import { CodeCollapsibleWrapper } from "./code-collapsible-wrapper"
 import { Button } from "./ui/button"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs"
 import { Code as CodeInline } from "./ui/typography"
 import { OpenInV0Button } from "./v0-open-button"
 
@@ -19,7 +25,7 @@ export function ComponentPreview({
   name,
   openInV0Url,
   canReplay = false,
-  notProse = true,
+  prose = false,
   codeCollapsible = false,
   remountOnThemeChange = false,
   children,
@@ -28,7 +34,7 @@ export function ComponentPreview({
   name: string
   openInV0Url?: string
   canReplay?: boolean
-  notProse?: boolean
+  prose?: boolean
   codeCollapsible?: boolean
   remountOnThemeChange?: boolean
 }) {
@@ -55,36 +61,30 @@ export function ComponentPreview({
 
   return (
     <div
-      className={cn("my-[1.25em]", notProse && "not-prose", className)}
+      className={cn("my-[1.25em]", prose === false && "not-prose", className)}
       {...props}
     >
       <Tabs defaultValue="preview" className="gap-4">
         <TabsList>
-          <TabsTrigger className="px-2.5" value="preview">
-            <EyeIcon />
-            Preview
-          </TabsTrigger>
-          <TabsTrigger className="px-2.5" value="code">
-            <CodeXmlIcon />
-            Code
-          </TabsTrigger>
+          <TabsTrigger value="preview">Preview</TabsTrigger>
+          <TabsTrigger value="code">Code</TabsTrigger>
+          <TabsIndicator />
         </TabsList>
 
         <TabsContent value="preview">
           <div
             data-slot="preview"
             className="rounded-xl border border-line p-2"
-            // className="bg-zinc-950/0.75 bg-[radial-gradient(var(--pattern-foreground)_1px,transparent_0)] bg-size-[10px_10px] [--pattern-foreground:var(--color-zinc-950)]/5 dark:bg-white/0.75 dark:[--pattern-foreground:var(--color-white)]/5"
           >
             {(canReplay || openInV0Url) && (
-              <div data-slot="buttons" className="mb-2 flex justify-end gap-2">
+              <div data-slot="buttons" className="mb-2 flex justify-end">
                 {canReplay && (
                   <Tooltip>
                     <TooltipTrigger
                       render={
                         <Button
-                          className="rounded-md"
-                          variant="secondary"
+                          className="border-none"
+                          variant="ghost"
                           size="icon-sm"
                           aria-label="Replay"
                           onClick={() => setReplay((v) => v + 1)}
@@ -123,7 +123,10 @@ export function ComponentPreview({
           </div>
         </TabsContent>
 
-        <TabsContent value="code" className="[&>figure]:m-0">
+        <TabsContent
+          value="code"
+          className="*:data-rehype-pretty-code-figure:m-0"
+        >
           {codeCollapsible ? (
             <CodeCollapsibleWrapper className="my-0">
               {Code}

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -40,7 +40,7 @@ import { AutoTypeTable } from "@/registry/components/auto-type-table"
 
 import { Callout } from "./callout"
 import { CodeTabs } from "./code-tabs"
-import { ComponentPreviewV2 as ComponentPreview } from "./component-preview-v2"
+import { ComponentPreview } from "./component-preview"
 import { FramedImage, IframeEmbed, YouTubeEmbed } from "./embed"
 import { mdxCodeBlockComponents } from "./mdx-code-block"
 import { Testimonial } from "./testimonial"


### PR DESCRIPTION
- Remove gap-0 class from buttons container in ComponentPreviewV2
- Add aria-label to replay button in ComponentPreviewV2
- Replace ComponentPreviewV2 with ComponentPreview in mdx imports
- Update ComponentPreview to use base tabs with indicator
- Rename notProse prop to prose with inverted logic
- Simplify tab triggers by removing icons
- Update button styling from secondary to ghost variant
- Fix code content selector using modern CSS syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Improved accessibility with enhanced button labels for replay controls.

* **Style**
  - Adjusted button spacing in preview control areas.
  - Refined tab interface with text-based triggers and visible indicator styling.
  - Updated replay button appearance for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->