### PR TITLE
style: update border radius from xl to 2xl in doc sponsors component

### DIFF
--- a/src/features/doc/components/doc-sponsors.tsx
+++ b/src/features/doc/components/doc-sponsors.tsx
@@ -7,12 +7,12 @@ const GOLD_SPONSORS = SPONSORS.filter((sponsor) => sponsor.tier === "gold")
 export function DocSponsors() {
   return (
     <aside
-      className="not-prose my-12 rounded-xl border border-line p-1"
+      className="not-prose my-12 rounded-2xl border border-line p-1"
       aria-labelledby="doc-sponsors-heading"
     >
       <h2
         id="doc-sponsors-heading"
-        className="px-3 pt-2 pb-3 font-heading text-sm/none font-medium tracking-tight text-muted-foreground"
+        className="px-3 pt-2 pb-3 font-heading text-sm/none font-medium text-muted-foreground"
       >
         Gold Sponsors
       </h2>
@@ -21,7 +21,7 @@ export function DocSponsors() {
         {GOLD_SPONSORS.map((item) => (
           <li key={item.name}>
             <a
-              className="flex items-center justify-center rounded-lg border border-line text-foreground transition-[background-color] ease-out hover:bg-accent-muted [&_svg]:w-full [&_svg]:max-w-75 [&_svg]:shrink-0"
+              className="flex items-center justify-center rounded-xl border text-foreground transition-[background-color] ease-out hover:bg-accent-muted [&_svg]:w-full [&_svg]:max-w-75 [&_svg]:shrink-0"
               href={addQueryParams(item.url, UTM_PARAMS)}
               target="_blank"
               rel="noopener sponsored"

--- a/src/features/doc/content/apple-hello-effect.mdx
+++ b/src/features/doc/content/apple-hello-effect.mdx
@@ -35,6 +35,8 @@ updatedAt: 2026-04-05
   canReplay
 />
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/code-block-command.mdx
+++ b/src/features/doc/content/code-block-command.mdx
@@ -20,6 +20,8 @@ updatedAt: 2026-04-06
 - Copy commands instantly with smooth animations showing success or failure states.
 - `convertNpmCommand` utility to auto-convert a standard npm command to all package managers.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/consent-manager.mdx
+++ b/src/features/doc/content/consent-manager.mdx
@@ -28,6 +28,8 @@ updatedAt: 2026-03-01
 - Theme customized to match [shadcn/ui](https://ui.shadcn.com/docs/theming).
 - Designed for Next.js, adaptable to other frameworks via [c15t docs](https://c15t.com).
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/copy-button.mdx
+++ b/src/features/doc/content/copy-button.mdx
@@ -22,6 +22,8 @@ updatedAt: 2026-04-20
 - Accepts a string or function for dynamic content.
 - Callback support for success and error events.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/elastic-slider.mdx
+++ b/src/features/doc/content/elastic-slider.mdx
@@ -31,6 +31,8 @@ updatedAt: 2026-04-18
 
 > Want to craft components with meticulous attention to detail—like an Elastic Slider? I highly recommend the [Interface Craft](https://www.interfacecraft.dev) course by [Josh Puckett](https://joshpuckett.me).
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/github-contributions.mdx
+++ b/src/features/doc/content/github-contributions.mdx
@@ -20,6 +20,8 @@ updatedAt: 2026-04-18
 - Loads contribution data from Jonathan Gruber's [GitHub Contributions API](https://github.com/grubersjoe/github-contributions-api).
 - Uses Next.js `unstable_cache` with a one-day revalidation window, then passes a `Promise` into the client and resolves it with React `use()`
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/github-stars.mdx
+++ b/src/features/doc/content/github-stars.mdx
@@ -20,6 +20,8 @@ updatedAt: 2026-03-28
 - Formats large numbers for better readability (e.g., 1.2k for 1200).
 - Includes a tooltip that shows the full star count on hover.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/glow-card-grid.mdx
+++ b/src/features/doc/content/glow-card-grid.mdx
@@ -12,6 +12,8 @@ updatedAt: 2026-03-30
   openInV0Url="https://chanhdai.com/r/glow-card-grid-demo-01.json"
 />
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/haptic.mdx
+++ b/src/features/doc/content/haptic.mdx
@@ -15,6 +15,8 @@ updatedAt: 2026-03-03
 - Supports custom duration and vibration patterns on Android devices.
 - The haptic functionality was inspired by the [Vercel](https://vercel.com) mobile experience.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/middle-truncation.mdx
+++ b/src/features/doc/content/middle-truncation.mdx
@@ -18,6 +18,8 @@ updatedAt: 2026-04-01
 - Pixel-accurate measurement based on actual rendered text width.
 - Automatically recalculates when container resizes.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/react-wheel-picker.mdx
+++ b/src/features/doc/content/react-wheel-picker.mdx
@@ -21,6 +21,8 @@ Built on top of [React Wheel Picker](https://react-wheel-picker.chanhdai.com).
 - Unstyled core for complete style customization.
 - Full keyboard navigation and type-ahead search.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/scroll-fade-effect.mdx
+++ b/src/features/doc/content/scroll-fade-effect.mdx
@@ -17,6 +17,8 @@ updatedAt: 2026-02-20
 - Content fades in and out smoothly as you scroll.
 - Supports both vertical and horizontal scrolling.
 
+<DocSponsors />
+
 ## Browser Compatibility
 
 This component uses CSS `animation-timeline: scroll()`. Check the latest [browser compatibility on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline#browser_compatibility) before using in production.

--- a/src/features/doc/content/shimmering-text.mdx
+++ b/src/features/doc/content/shimmering-text.mdx
@@ -13,6 +13,8 @@ updatedAt: 2026-02-20
   remountOnThemeChange
 />
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/slide-to-unlock.mdx
+++ b/src/features/doc/content/slide-to-unlock.mdx
@@ -31,6 +31,8 @@ updatedAt: 2026-02-20
 
 > Want to build animations like Slide to Unlock? I highly recommend [Emil Kowalski](https://x.com/emilkowalski)’s animations.dev course. [Take the course](https://animations.dev)
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/testimonial-spotlight.mdx
+++ b/src/features/doc/content/testimonial-spotlight.mdx
@@ -9,6 +9,8 @@ updatedAt: 2026-03-27
 
 <ComponentPreview name="testimonial-spotlight-demo-01" />
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/testimonial.mdx
+++ b/src/features/doc/content/testimonial.mdx
@@ -12,6 +12,8 @@ updatedAt: 2026-03-28
   openInV0Url="https://chanhdai.com/r/testimonial.json"
 />
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/testimonials-marquee.mdx
+++ b/src/features/doc/content/testimonials-marquee.mdx
@@ -19,6 +19,8 @@ updatedAt: 2025-03-27
 - Single and multiple row layouts.
 - Composable with the Testimonial component.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/text-flip.mdx
+++ b/src/features/doc/content/text-flip.mdx
@@ -12,6 +12,8 @@ updatedAt: 2026-02-20
   openInV0Url="https://chanhdai.com/r/text-flip.json"
 />
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/theme-switcher.mdx
+++ b/src/features/doc/content/theme-switcher.mdx
@@ -12,6 +12,8 @@ updatedAt: 2026-02-12
   openInV0Url="https://chanhdai.com/r/theme-switcher.json"
 />
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/theme-toggle-effect.mdx
+++ b/src/features/doc/content/theme-toggle-effect.mdx
@@ -23,6 +23,8 @@ updatedAt: 2026-04-10
 
 This component uses the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API). Check the latest [browser compatibility on MDN](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API#browser_compatibility) before using in production.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/twemoji.mdx
+++ b/src/features/doc/content/twemoji.mdx
@@ -18,6 +18,8 @@ updatedAt: 2026-04-07
 - Customizable image source for self-hosting or alternative CDNs.
 - Server component compatible.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>

--- a/src/features/doc/content/work-experience-component.mdx
+++ b/src/features/doc/content/work-experience-component.mdx
@@ -20,6 +20,8 @@ updatedAt: 2026-03-28
 - Markdown rendering for position descriptions.
 - Company logos and duration display.
 
+<DocSponsors />
+
 ## Installation
 
 <CodeTabs>


### PR DESCRIPTION
feat: add DocSponsors component to all documentation pages to display gold sponsors consistently across component docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined border radius and typography styling in the sponsors section component.

* **New Features**
  * Integrated sponsor sections across multiple documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->