### PR TITLE
refactor: replace inline link styles with link-underline utility class

### DIFF
--- a/src/components/callout.tsx
+++ b/src/components/callout.tsx
@@ -20,11 +20,9 @@ export function Callout({
     >
       {icon}
       {title && (
-        <AlertTitle className="[&_a]:decoration-1 [&_a]:underline-offset-3">
-          {title}
-        </AlertTitle>
+        <AlertTitle className="[&_a]:link-underline">{title}</AlertTitle>
       )}
-      <AlertDescription className="text-surface-foreground/80 [&_a]:decoration-1 [&_a]:underline-offset-3">
+      <AlertDescription className="text-surface-foreground/80 [&_a]:link-underline">
         {children}
       </AlertDescription>
     </Alert>

--- a/src/features/doc/content/elastic-slider.mdx
+++ b/src/features/doc/content/elastic-slider.mdx
@@ -29,7 +29,12 @@ updatedAt: 2026-04-18
 - Inline label and value text dynamically fade to avoid handle overlap.
 - Supports keyboard navigation and respects `prefers-reduced-motion`
 
-> Want to craft components with meticulous attention to detail—like an Elastic Slider? I highly recommend the [Interface Craft](https://www.interfacecraft.dev) course by [Josh Puckett](https://joshpuckett.me).
+<Callout>
+  Want to craft components with meticulous attention to detail—like an Elastic
+  Slider? I highly recommend the [Interface
+  Craft](https://www.interfacecraft.dev) course by [Josh
+  Puckett](https://joshpuckett.me).
+</Callout>
 
 <DocSponsors />
 

--- a/src/features/doc/content/slide-to-unlock.mdx
+++ b/src/features/doc/content/slide-to-unlock.mdx
@@ -29,7 +29,11 @@ updatedAt: 2026-02-20
 - Customizable handle and colors.
 - Built-in shimmering text effect.
 
-> Want to build animations like Slide to Unlock? I highly recommend [Emil Kowalski](https://x.com/emilkowalski)’s animations.dev course. [Take the course](https://animations.dev)
+<Callout>
+  Want to build animations like Slide to Unlock? I highly recommend [Emil
+  Kowalski](https://x.com/emilkowalski)’s animations.dev course. [Take the
+  course](https://animations.dev)
+</Callout>
 
 <DocSponsors />
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -153,7 +153,7 @@
   @apply prose-code:rounded-md prose-code:border prose-code:bg-muted/50 prose-code:px-[0.3rem] prose-code:py-[0.2rem] prose-code:text-sm prose-code:font-normal prose-code:before:content-none prose-code:after:content-none;
   @apply prose-strong:font-medium;
   @apply prose-hr:border-line;
-  @apply prose-blockquote:border-s-2 prose-blockquote:font-normal prose-blockquote:text-muted-foreground prose-blockquote:not-italic prose-blockquote:[&_p:first-of-type]:before:content-none prose-blockquote:[&_p:last-of-type]:after:content-none;
+  @apply prose-blockquote:border-l prose-blockquote:border-line prose-blockquote:font-normal prose-blockquote:text-muted-foreground prose-blockquote:not-italic prose-blockquote:[&_p:first-of-type]:before:content-none prose-blockquote:[&_p:last-of-type]:after:content-none;
 }
 
 @utility code-inline {


### PR DESCRIPTION
style: convert blockquotes to Callout components in documentation

fix: change blockquote border from border-s-2 to border-l border-line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated blockquote and callout styling with refined visual presentation and improved border treatment
* **Documentation**
  * Improved display of course recommendations in tutorial documentation by replacing standard blockquotes with styled callout components for better visual hierarchy and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->