### PR TITLE
style: standardize icon sizing and button styling across components

### DIFF
--- a/src/app/(app)/(pages)/components/page.tsx
+++ b/src/app/(app)/(pages)/components/page.tsx
@@ -89,7 +89,7 @@ export default function Page() {
                 variant="secondary"
                 size="sm"
               >
-                <PlusIcon className="size-3.5" />
+                <PlusIcon />
                 Add
               </Button>
             }

--- a/src/components/code-block-command.tsx
+++ b/src/components/code-block-command.tsx
@@ -81,7 +81,8 @@ export function CodeBlockCommand({
       </Tabs>
 
       <CopyButton
-        className="absolute top-2 right-2 z-10 rounded-md border-none"
+        className="absolute top-1.5 right-1.5 z-10 size-7 rounded-md border-none text-muted-foreground [&_svg:not([class*='size-'])]:size-4"
+        variant="ghost"
         size="icon-xs"
         text={tabs[packageManager] || ""}
         event="copy_npm_command"

--- a/src/components/component-preview.tsx
+++ b/src/components/component-preview.tsx
@@ -61,29 +61,44 @@ export function ComponentPreview({
 
   return (
     <div
-      className={cn("my-[1.25em]", prose === false && "not-prose", className)}
+      className={cn(
+        "my-[1.25em] rounded-xl bg-code",
+        prose === false && "not-prose",
+        className
+      )}
       {...props}
     >
-      <Tabs defaultValue="preview" className="gap-4">
-        <TabsList>
-          <TabsTrigger value="preview">Preview</TabsTrigger>
-          <TabsTrigger value="code">Code</TabsTrigger>
-          <TabsIndicator />
-        </TabsList>
+      <Tabs defaultValue="preview" className="gap-0">
+        <div className="z-1 px-4">
+          <TabsList className="h-10 rounded-none bg-transparent p-0 dark:bg-transparent [&_svg]:me-2 [&_svg]:size-4 [&_svg]:text-muted-foreground">
+            <TabsTrigger className="h-7 rounded-lg p-0 px-2" value="preview">
+              Preview
+            </TabsTrigger>
+            <TabsTrigger className="h-7 rounded-lg p-0 px-2" value="code">
+              Code
+            </TabsTrigger>
 
-        <TabsContent value="preview">
+            <TabsIndicator className="h-0.5 translate-y-px rounded-none bg-foreground shadow-none dark:bg-foreground" />
+          </TabsList>
+        </div>
+
+        <TabsContent className="px-1 pb-1" value="preview">
           <div
             data-slot="preview"
-            className="rounded-xl border border-line p-2"
+            data-show-buttons={canReplay || !!openInV0Url}
+            className="relative rounded-xl rounded-b-[9px] border bg-background p-2 data-[show-buttons=true]:py-10.5"
           >
             {(canReplay || openInV0Url) && (
-              <div data-slot="buttons" className="mb-2 flex justify-end">
+              <div
+                data-slot="buttons"
+                className="absolute top-1.5 right-1.5 flex justify-end"
+              >
                 {canReplay && (
                   <Tooltip>
                     <TooltipTrigger
                       render={
                         <Button
-                          className="border-none"
+                          className="size-7 rounded-md border-none"
                           variant="ghost"
                           size="icon-sm"
                           aria-label="Replay"
@@ -99,7 +114,12 @@ export function ComponentPreview({
                   </Tooltip>
                 )}
 
-                {openInV0Url && <OpenInV0Button url={openInV0Url} />}
+                {openInV0Url && (
+                  <OpenInV0Button
+                    className="h-7 rounded-md"
+                    url={openInV0Url}
+                  />
+                )}
               </div>
             )}
 
@@ -118,14 +138,16 @@ export function ComponentPreview({
                 {Preview}
               </React.Suspense>
             </div>
-
-            {(canReplay || openInV0Url) && <div className="mt-2 h-7" />}
           </div>
         </TabsContent>
 
         <TabsContent
           value="code"
-          className="*:data-rehype-pretty-code-figure:m-0"
+          className={cn(
+            "px-1 pb-1 [--code:var(--background)]",
+            "*:data-rehype-pretty-code-figure:m-0 *:data-rehype-pretty-code-figure:rounded-b-[9px] *:data-rehype-pretty-code-figure:border",
+            "**:data-[slot=copy-button]:size-7"
+          )}
         >
           {codeCollapsible ? (
             <CodeCollapsibleWrapper className="my-0">

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -5,6 +5,8 @@ import { trackEvent } from "@/lib/events"
 import type { CopyButtonProps } from "@/registry/components/copy-button"
 import { CopyButton as CopyButtonPrimitive } from "@/registry/components/copy-button"
 
+import { Icons } from "./icons"
+
 export function CopyButton({
   size = "icon-sm",
   event,
@@ -16,6 +18,7 @@ export function CopyButton({
     <CopyButtonPrimitive
       variant="secondary"
       size={size}
+      idleIcon={<Icons.copy />}
       onCopySuccess={(copiedValue) => {
         if (event) {
           trackEvent({

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -616,6 +616,24 @@ export const Icons = {
       />
     </svg>
   ),
+
+  // Source: tabler.io/icons
+  copy: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M7 9.667a2.667 2.667 0 0 1 2.667 -2.667h8.666a2.667 2.667 0 0 1 2.667 2.667v8.666a2.667 2.667 0 0 1 -2.667 2.667h-8.666a2.667 2.667 0 0 1 -2.667 -2.667l0 -8.666" />
+      <path d="M4.012 16.737a2.005 2.005 0 0 1 -1.012 -1.737v-10c0 -1.1 .9 -2 2 -2h10c.75 0 1.158 .385 1.5 1" />
+    </svg>
+  ),
 }
 
 export function getIconForLanguageExtension(language: string) {

--- a/src/components/mdx-code-block.tsx
+++ b/src/components/mdx-code-block.tsx
@@ -72,7 +72,9 @@ export const mdxCodeBlockComponents = {
         {__rawString__ && (
           <>
             <CopyButton
-              className="absolute top-2 right-2 z-10 rounded-md border-none"
+              data-slot="copy-button"
+              className="absolute top-1.5 right-1.5 z-10 size-7 rounded-md border-none text-muted-foreground [&_svg:not([class*='size-'])]:size-4"
+              variant="ghost"
               size="icon-xs"
               text={__rawString__}
               event="copy_code_block"

--- a/src/components/registry-command-animated.tsx
+++ b/src/components/registry-command-animated.tsx
@@ -111,7 +111,7 @@ export function RegistryCommandAnimated() {
       </Tabs>
 
       <CopyButton
-        className="absolute top-1.5 right-1.5 z-10 size-7 border-none [&_svg:not([class*='size-'])]:size-3.5"
+        className="absolute top-1.5 right-1.5 z-10 size-7 border-none"
         size="icon-sm"
         text={() => {
           const baseCommand = pmCommands[packageManager] || pmCommands["pnpm"]

--- a/src/features/blog/components/post-page-actions.tsx
+++ b/src/features/blog/components/post-page-actions.tsx
@@ -68,14 +68,14 @@ export function LLMCopyButton({ markdownUrl }: { markdownUrl: string }) {
 
   return (
     <Button
-      className="h-7 gap-1.5 border-none pr-2 pl-2.5 text-[0.8125rem] active:scale-none [&_svg:not([class*='size-'])]:size-3.5"
+      className="h-7 gap-1.5 border-none px-2 text-[0.8125rem] active:scale-none"
       variant="secondary"
       size="sm"
       aria-busy={isCopying}
       disabled={isCopying}
       onClick={handleCopy}
     >
-      <CopyStateIcon state={state} />
+      <CopyStateIcon state={state} idleIcon={<Icons.copy />} />
       <span className="max-[28rem]:hidden">Copy Page</span>
     </Button>
   )


### PR DESCRIPTION
Remove explicit size classes from icons and buttons to rely on consistent default sizing. Update copy buttons with ghost variant and standardized positioning. Improve component preview layout with better spacing and background styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined copy button positioning, sizing, and visual styling across multiple components
  * Enhanced component preview styling with improved visual hierarchy and rounded corners
  * Restructured tab UI layout for better organization
  * Updated icon rendering for copy actions with improved visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->