### PR TITLE
style: add retina display support and clean up code formatting

### DIFF
--- a/src/components/callout.tsx
+++ b/src/components/callout.tsx
@@ -13,7 +13,7 @@ export function Callout({
   return (
     <Alert
       className={cn(
-        "not-prose rounded-xl bg-surface text-surface-foreground",
+        "not-prose rounded-xl bg-surface text-surface-foreground retina:border-[0.5px]",
         className
       )}
       {...props}

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -43,11 +43,7 @@ function Code({ className, ...props }: React.ComponentProps<"code">) {
   return (
     <code
       data-slot={isCodeBlock ? "code-block" : "code-inline"}
-      className={cn(
-        // !isCodeBlock && "not-prose rounded-md border bg-muted/50 px-1.5 py-0.5 font-mono text-sm whitespace-pre-wrap in-data-table-nowrap:whitespace-nowrap",
-        !isCodeBlock && "not-prose code-inline",
-        className
-      )}
+      className={cn(!isCodeBlock && "not-prose code-inline", className)}
       {...props}
     />
   )

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -72,6 +72,12 @@
   }
 }
 
+@custom-variant retina {
+  @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2x) {
+    @slot;
+  }
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);


### PR DESCRIPTION
Add custom retina variant for high-DPI displays, apply retina border to callout component, and remove commented code from typography

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced support for high-density (retina) displays with improved border rendering on the Callout component.
  * Simplified styling logic for the Code component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->