### PR TITLE
style: add retina display border refinements for high-DPI screens

### DIFF
--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -7,7 +7,7 @@ function Tag({ className, ...props }: React.ComponentProps<"span">) {
     <span
       data-slot="tag"
       className={cn(
-        "inline-flex items-center rounded-md border bg-zinc-50 px-1.5 py-0.5 font-mono text-xs text-muted-foreground dark:bg-zinc-900",
+        "inline-flex items-center rounded-md border bg-zinc-50 px-1.5 py-0.5 font-mono text-xs text-muted-foreground dark:bg-zinc-900 retina:border-[0.5px]",
         "[&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
         className
       )}

--- a/src/features/portfolio/components/profile-header.tsx
+++ b/src/features/portfolio/components/profile-header.tsx
@@ -9,7 +9,7 @@ export function ProfileHeader() {
   return (
     <div className="screen-line-bottom flex border-x border-line">
       <div className="shrink-0 border-r border-line">
-        <div className="mx-0.5 my-0.75">
+        <div className="relative mx-0.5 my-0.75">
           <AvatarElectricEffect>
             <img
               className="size-30 rounded-full ring-1 ring-border ring-offset-2 ring-offset-background select-none sm:size-40"
@@ -18,6 +18,7 @@ export function ProfileHeader() {
               fetchPriority="high"
             />
           </AvatarElectricEffect>
+          <div className="pointer-events-none absolute inset-0 rounded-full ring-1 ring-black/10 ring-inset dark:ring-white/15 retina:ring-[0.5px]" />
         </div>
       </div>
 

--- a/src/features/portfolio/components/tech-stack.tsx
+++ b/src/features/portfolio/components/tech-stack.tsx
@@ -20,7 +20,7 @@ export function TechStack() {
                   target="_blank"
                   rel="noopener"
                   aria-label={tech.title}
-                  className="flex items-center gap-1.5 rounded-full border bg-zinc-50 px-1.5 py-0.5 text-xs tracking-wide text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 [&_img]:size-3.5 [&_img]:select-none"
+                  className="flex items-center gap-1.5 rounded-full border bg-zinc-50 px-1.5 py-0.5 text-xs tracking-wide text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 retina:border-[0.5px] [&_img]:size-3.5 [&_img]:select-none"
                 >
                   {tech.theme ? (
                     <>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -156,14 +156,14 @@
 @utility prose-ncdai {
   @apply prose-headings:tracking-tight prose-headings:text-balance prose-h2:font-semibold;
   @apply prose-a:font-normal prose-a:wrap-break-word prose-a:text-foreground prose-a:link-underline;
-  @apply prose-code:rounded-md prose-code:border prose-code:bg-muted/50 prose-code:px-[0.3rem] prose-code:py-[0.2rem] prose-code:text-sm prose-code:font-normal prose-code:before:content-none prose-code:after:content-none;
+  @apply prose-code:rounded-md prose-code:border prose-code:bg-muted/50 prose-code:px-[0.3rem] prose-code:py-[0.2rem] prose-code:text-sm prose-code:font-normal prose-code:before:content-none prose-code:after:content-none retina:prose-code:border-[0.5px];
   @apply prose-strong:font-medium;
   @apply prose-hr:border-line;
   @apply prose-blockquote:border-l prose-blockquote:border-line prose-blockquote:font-normal prose-blockquote:text-muted-foreground prose-blockquote:not-italic prose-blockquote:[&_p:first-of-type]:before:content-none prose-blockquote:[&_p:last-of-type]:after:content-none;
 }
 
 @utility code-inline {
-  @apply rounded-md border bg-muted/50 px-1.5 py-0.5 font-mono text-[0.8125rem] whitespace-pre-wrap in-data-table-nowrap:whitespace-nowrap;
+  @apply rounded-md border bg-muted/50 px-1.5 py-0.5 font-mono text-[0.8125rem] whitespace-pre-wrap in-data-table-nowrap:whitespace-nowrap retina:border-[0.5px];
 }
 
 @utility prose-no-margin {


### PR DESCRIPTION
Add 0.5px borders for retina displays to improve visual clarity on high-resolution screens across tag, profile header, tech stack, and code elements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced retina display support with optimized border rendering across UI components
  * Added subtle visual refinement to avatar with improved appearance on high-DPI screens
  * Improved code styling with pixel-perfect rendering for high-density displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->