### PR TITLE
style: remove showLineNumbers from code blocks and update styling

### DIFF
--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -68,8 +68,8 @@ const components: MDXRemoteProps["components"] = {
   Steps: ({ className, ...props }: React.ComponentProps<"div">) => (
     <div
       className={cn(
-        "relative md:ml-3.5 md:pl-7.5 prose-h3:text-lg prose-h3:text-pretty",
-        "before:pointer-events-none before:absolute before:top-0 before:left-0 before:hidden before:h-full before:w-px before:-translate-x-1/2 before:bg-border before:md:flex",
+        "relative md:ml-3 md:pl-7 prose-h3:text-base prose-h3:text-pretty",
+        "before:pointer-events-none before:absolute before:top-0 before:left-0 before:hidden before:h-full before:w-px before:-translate-x-1/2 before:bg-line before:md:flex",
         className
       )}
       {...props}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -11,7 +11,7 @@ export function SiteFooter() {
       <div className="screen-line-top mx-auto border-x border-line pt-4 group-has-data-[slot=layout-wide]/layout:container md:max-w-3xl">
         <p className="mb-1 px-4 text-center font-mono text-sm text-balance text-muted-foreground [&_span]:mx-0.5 [&_span]:inline-block">
           Inspired by tailwindcss.com<span>/</span>ui.shadcn.com<span>/</span>
-          vercel.com
+          vercel.com<span>/</span>evilcharts.com
         </p>
 
         <p className="mb-4 px-4 text-center font-mono text-sm text-balance text-muted-foreground">

--- a/src/features/doc/content/apple-hello-effect.mdx
+++ b/src/features/doc/content/apple-hello-effect.mdx
@@ -86,7 +86,6 @@ npm install motion clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -97,7 +96,6 @@ For English:
 <ComponentSource
   name="apple-hello-effect"
   title="components/apple-hello-effect-english.tsx"
-  showLineNumbers
 />
 
 For Hindi:
@@ -105,7 +103,6 @@ For Hindi:
 <ComponentSource
   name="apple-hello-effect-hindi"
   title="components/apple-hello-effect-hindi.tsx"
-  showLineNumbers
 />
 
 For Spanish:
@@ -113,7 +110,6 @@ For Spanish:
 <ComponentSource
   name="apple-hello-effect-spanish"
   title="components/apple-hello-effect-spanish.tsx"
-  showLineNumbers
 />
 
 For Vietnamese:
@@ -121,7 +117,6 @@ For Vietnamese:
 <ComponentSource
   name="apple-hello-effect-vietnamese"
   title="components/apple-hello-effect-vietnamese.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>

--- a/src/features/doc/content/code-block-command.mdx
+++ b/src/features/doc/content/code-block-command.mdx
@@ -51,7 +51,6 @@ npm install clsx tailwind-merge class-variance-authority lucide-react motion jot
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -64,13 +63,11 @@ npm install clsx tailwind-merge class-variance-authority lucide-react motion jot
 <ComponentSource
   src="src/components/base/ui/tabs.tsx"
   title="components/tabs.tsx"
-  showLineNumbers
 />
 
 <ComponentSource
   name="code-block-command"
   title="components/code-block-command.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>
@@ -153,7 +150,7 @@ Use `convertNpmCommand` to avoid manually writing commands for each package mana
 
 Track user interactions with analytics services like [PostHog](https://posthog.com), [OpenPanel](https://openpanel.dev), or [Google Analytics](https://analytics.google.com).
 
-```tsx showLineNumbers {3,12}
+```tsx {3,12}
 <CodeBlockCommand
   {...convertNpmCommand("npx shadcn add @ncdai/code-block-command")}
   onCopySuccess={({ packageManager, command }) => {

--- a/src/features/doc/content/consent-manager.mdx
+++ b/src/features/doc/content/consent-manager.mdx
@@ -59,7 +59,6 @@ npm install clsx tailwind-merge @c15t/nextjs
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -72,7 +71,6 @@ npm install clsx tailwind-merge @c15t/nextjs
 <ComponentSource
   name="consent-manager"
   title="components/consent-manager.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>
@@ -87,7 +85,7 @@ npm install clsx tailwind-merge @c15t/nextjs
 
 Wrap your app with the `ConsentManager` component:
 
-```tsx title="app/layout.tsx" showLineNumbers {1,7}
+```tsx title="app/layout.tsx" {1,7}
 import { ConsentManager } from "@/components/consent-manager"
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/src/features/doc/content/copy-button.mdx
+++ b/src/features/doc/content/copy-button.mdx
@@ -53,7 +53,6 @@ npm install clsx tailwind-merge class-variance-authority lucide-react motion rad
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -66,14 +65,9 @@ npm install clsx tailwind-merge class-variance-authority lucide-react motion rad
 <ComponentSource
   src="src/hooks/use-copy-to-clipboard.ts"
   title="hooks/use-copy-to-clipboard.ts"
-  showLineNumbers
 />
 
-<ComponentSource
-  name="copy-button"
-  title="components/copy-button.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="copy-button" title="components/copy-button.tsx" />
 
 <Step>Update the import paths to match your project setup</Step>
 

--- a/src/features/doc/content/elastic-slider.mdx
+++ b/src/features/doc/content/elastic-slider.mdx
@@ -67,7 +67,6 @@ npm install motion clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -76,14 +75,9 @@ npm install motion clsx tailwind-merge
 <ComponentSource
   name="use-controllable-state"
   title="hooks/use-controllable-state.tsx"
-  showLineNumbers
 />
 
-<ComponentSource
-  name="elastic-slider"
-  title="components/elastic-slider.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="elastic-slider" title="components/elastic-slider.tsx" />
 
 <Step>Update the import paths to match your project setup</Step>
 

--- a/src/features/doc/content/github-contributions.mdx
+++ b/src/features/doc/content/github-contributions.mdx
@@ -49,19 +49,16 @@ npx shadcn@latest add @ncdai/github-contributions
 <ComponentSource
   name="contribution-graph"
   title="components/contribution-graph.tsx"
-  showLineNumbers
 />
 
 <ComponentSource
   name="github-contributions"
   title="components/github-contributions.tsx"
-  showLineNumbers
 />
 
 <ComponentSource
   src="src/registry/components/github-contributions/lib/get-cached-contributions.ts"
   title="lib/get-cached-contributions.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>
@@ -74,11 +71,7 @@ npx shadcn@latest add @ncdai/github-contributions
 
 ## Usage
 
-<ComponentSource
-  name="github-contributions-demo"
-  collapsible="false"
-  showLineNumbers
-/>
+<ComponentSource name="github-contributions-demo" collapsible="false" />
 
 ## API Reference
 

--- a/src/features/doc/content/github-stars.mdx
+++ b/src/features/doc/content/github-stars.mdx
@@ -47,11 +47,7 @@ npx shadcn@latest add @ncdai/github-stars
 
 <Step>Copy and paste the following code into your project</Step>
 
-<ComponentSource
-  name="github-stars"
-  title="components/github-stars.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="github-stars" title="components/github-stars.tsx" />
 
 <Step>Update the import paths to match your project setup</Step>
 
@@ -84,8 +80,4 @@ import { GithubStars } from "@/components/github-stars"
 
 ### Fetching GitHub Stars with Server Component
 
-<ComponentSource
-  src="src/components/nav-item-github.tsx"
-  showLineNumbers
-  collapsible="false"
-/>
+<ComponentSource src="src/components/nav-item-github.tsx" collapsible="false" />

--- a/src/features/doc/content/glow-card-grid.mdx
+++ b/src/features/doc/content/glow-card-grid.mdx
@@ -43,7 +43,6 @@ npm install clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -52,13 +51,11 @@ npm install clsx tailwind-merge
 <ComponentSource
   src="src/registry/components/glow-card-grid/glow-card.tsx"
   title="components/glow-card.tsx"
-  showLineNumbers
 />
 
 <ComponentSource
   src="src/registry/components/glow-card-grid/glow-card-grid.tsx"
   title="components/glow-card-grid.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>

--- a/src/features/doc/content/haptic.mdx
+++ b/src/features/doc/content/haptic.mdx
@@ -37,7 +37,7 @@ npx shadcn@latest add @ncdai/haptic
 
 <Step>Copy and paste the following code into your project</Step>
 
-<ComponentSource name="haptic" title="lib/haptic.ts" showLineNumbers />
+<ComponentSource name="haptic" title="lib/haptic.ts" />
 
 <Step>Update the import paths to match your project setup</Step>
 

--- a/src/features/doc/content/middle-truncation.mdx
+++ b/src/features/doc/content/middle-truncation.mdx
@@ -49,7 +49,6 @@ npm install clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -58,7 +57,6 @@ npm install clsx tailwind-merge
 <ComponentSource
   name="middle-truncation"
   title="components/middle-truncation.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>

--- a/src/features/doc/content/react-wheel-picker.mdx
+++ b/src/features/doc/content/react-wheel-picker.mdx
@@ -52,17 +52,12 @@ npm install @ncdai/react-wheel-picker clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
 <Step>Copy and paste the following code into your project</Step>
 
-<ComponentSource
-  name="wheel-picker"
-  title="components/wheel-picker.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="wheel-picker" title="components/wheel-picker.tsx" />
 
 <Step>Update the import paths to match your project setup</Step>
 

--- a/src/features/doc/content/scroll-fade-effect.mdx
+++ b/src/features/doc/content/scroll-fade-effect.mdx
@@ -52,24 +52,18 @@ npm install clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
 <Step>Add Tailwind CSS utilities and animations</Step>
 
-<ComponentSource
-  src="src/styles/scroll-fade-effect.css"
-  title="globals.css"
-  showLineNumbers
-/>
+<ComponentSource src="src/styles/scroll-fade-effect.css" title="globals.css" />
 
 <Step>Copy and paste the following code into your project</Step>
 
 <ComponentSource
   name="scroll-fade-effect"
   title="components/scroll-fade-effect.tsx"
-  showLineNumbers
   collapsible="false"
 />
 

--- a/src/features/doc/content/shimmering-text.mdx
+++ b/src/features/doc/content/shimmering-text.mdx
@@ -44,7 +44,6 @@ npm install motion clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -53,7 +52,6 @@ npm install motion clsx tailwind-merge
 <ComponentSource
   name="shimmering-text"
   title="components/shimmering-text.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>

--- a/src/features/doc/content/slide-to-unlock.mdx
+++ b/src/features/doc/content/slide-to-unlock.mdx
@@ -66,7 +66,6 @@ npm install motion clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -75,13 +74,11 @@ npm install motion clsx tailwind-merge
 <ComponentSource
   name="shimmering-text"
   title="components/shimmering-text.tsx"
-  showLineNumbers
 />
 
 <ComponentSource
   name="slide-to-unlock"
   title="components/slide-to-unlock.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>

--- a/src/features/doc/content/testimonial-spotlight.mdx
+++ b/src/features/doc/content/testimonial-spotlight.mdx
@@ -40,22 +40,16 @@ npm install clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
 <Step>Copy and paste the following code into your project</Step>
 
-<ComponentSource
-  name="testimonial"
-  title="components/testimonial.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="testimonial" title="components/testimonial.tsx" />
 
 <ComponentSource
   name="testimonial-spotlight"
   title="components/testimonial-spotlight.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>

--- a/src/features/doc/content/testimonial.mdx
+++ b/src/features/doc/content/testimonial.mdx
@@ -43,17 +43,12 @@ npm install clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
 <Step>Copy and paste the following code into your project</Step>
 
-<ComponentSource
-  name="testimonial"
-  title="components/testimonial.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="testimonial" title="components/testimonial.tsx" />
 
 <Step>Update the import paths to match your project setup</Step>
 

--- a/src/features/doc/content/testimonials-marquee.mdx
+++ b/src/features/doc/content/testimonials-marquee.mdx
@@ -50,22 +50,16 @@ npm install clsx tailwind-merge react-fast-marquee
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
 <Step>Copy and paste the following code into your project</Step>
 
-<ComponentSource
-  name="testimonial"
-  title="components/testimonial.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="testimonial" title="components/testimonial.tsx" />
 
 <ComponentSource
   src="src/components/kibo-ui/marquee/index.tsx"
   title="components/kibo-ui/marquee/index.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>

--- a/src/features/doc/content/text-flip.mdx
+++ b/src/features/doc/content/text-flip.mdx
@@ -43,17 +43,12 @@ npm install motion clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
 <Step>Copy and paste the following code into your project</Step>
 
-<ComponentSource
-  name="text-flip"
-  title="components/text-flip.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="text-flip" title="components/text-flip.tsx" />
 
 <Step>Update the import paths to match your project setup</Step>
 

--- a/src/features/doc/content/theme-switcher.mdx
+++ b/src/features/doc/content/theme-switcher.mdx
@@ -43,17 +43,12 @@ npm install next-themes lucide-react motion clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
 <Step>Copy and paste the following code into your project</Step>
 
-<ComponentSource
-  name="theme-switcher"
-  title="components/theme-switcher.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="theme-switcher" title="components/theme-switcher.tsx" />
 
 <Step>Update the import paths to match your project setup</Step>
 

--- a/src/features/doc/content/toc-minimap.mdx
+++ b/src/features/doc/content/toc-minimap.mdx
@@ -51,7 +51,6 @@ npm install clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -61,11 +60,7 @@ npm install clsx tailwind-merge
 
 <Step>Copy and paste the following code into your project</Step>
 
-<ComponentSource
-  name="toc-minimap"
-  title="components/toc-minimap.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="toc-minimap" title="components/toc-minimap.tsx" />
 
 <Step>Update the import paths to match your project setup</Step>
 

--- a/src/features/doc/content/twemoji.mdx
+++ b/src/features/doc/content/twemoji.mdx
@@ -49,7 +49,6 @@ npm install clsx tailwind-merge
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
@@ -71,11 +70,7 @@ npm install clsx tailwind-merge
 
 <Step>Copy and paste the following code into your project</Step>
 
-<ComponentSource
-  name="twemoji"
-  title="components/twemoji.tsx"
-  showLineNumbers
-/>
+<ComponentSource name="twemoji" title="components/twemoji.tsx" />
 
 <Step>Update the import paths to match your project setup</Step>
 

--- a/src/features/doc/content/work-experience-component.mdx
+++ b/src/features/doc/content/work-experience-component.mdx
@@ -55,13 +55,12 @@ npm install -D @tailwindcss/typography
 <ComponentSource
   src="src/lib/utils.ts"
   title="lib/utils.ts"
-  showLineNumbers
   collapsible="false"
 />
 
 <Step>Add a Tailwind CSS plugin and utility</Step>
 
-```css title="globals.css" showLineNumbers
+```css title="globals.css"
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
@@ -91,13 +90,11 @@ npm install -D @tailwindcss/typography
 <ComponentSource
   name="chevrons-up-down-icon"
   title="components/chevrons-up-down-icon.tsx"
-  showLineNumbers
 />
 
 <ComponentSource
   name="work-experience"
   title="components/work-experience.tsx"
-  showLineNumbers
 />
 
 <Step>Update the import paths to match your project setup</Step>

--- a/src/lib/rehype-code-block.ts
+++ b/src/lib/rehype-code-block.ts
@@ -26,7 +26,7 @@ export function rehypeCodeRawString() {
 export function rehypeHighlightCode() {
   return rehypePrettyCode({
     theme: {
-      dark: "github-dark",
+      dark: "vesper",
       light: "github-light",
     },
     keepBackground: false,

--- a/src/lib/rehype-component.ts
+++ b/src/lib/rehype-component.ts
@@ -136,7 +136,7 @@ export function rehypeComponent() {
                     className: ["language-tsx"],
                   },
                   data: {
-                    meta: codeMeta,
+                    meta: codeMeta?.value ?? "",
                   },
                   children: [
                     {

--- a/src/lib/rehype-component.ts
+++ b/src/lib/rehype-component.ts
@@ -136,9 +136,7 @@ export function rehypeComponent() {
                     className: ["language-tsx"],
                   },
                   data: {
-                    meta: ["showLineNumbers"]
-                      .concat(codeMeta ? [codeMeta.value as string] : [])
-                      .join(" "),
+                    meta: codeMeta,
                   },
                   children: [
                     {

--- a/src/registry/components/auto-type-table/markdown.ts
+++ b/src/registry/components/auto-type-table/markdown.ts
@@ -42,6 +42,10 @@ export function markdownRenderer(options?: ShikiOptions): MarkdownRenderer {
       const nodes = await highlightHast(type, {
         lang: "ts",
         structure: "inline",
+        themes: {
+          dark: "vesper",
+          light: "github-light",
+        },
         defaultColor: false,
         ...options,
       })

--- a/src/registry/components/type-table/type-table.tsx
+++ b/src/registry/components/type-table/type-table.tsx
@@ -111,8 +111,8 @@ function Item({
       <CollapsibleTrigger className="not-prose relative flex w-full flex-row items-center rounded-lg px-3 py-2 text-start text-[0.8125rem] ring-border outline-none ring-inset group-data-open/type-item:rounded-b-none group-data-open/type-item:ring-1 hover:bg-accent focus-visible:ring-1 focus-visible:ring-ring/50 dark:hover:bg-[color-mix(in_oklab,var(--accent)_60%,var(--code))] [&_svg]:size-4">
         <code
           className={cn(
-            "[--shiki-dark:#79B8FF] [--shiki-light:#005CC5]",
-            "w-1/4 min-w-fit shrink-0 pe-2 font-mono font-medium text-(--shiki-light) dark:text-(--shiki-dark)",
+            "[--shiki-dark:var(--foreground)] [--shiki-light:#6F42C1]",
+            "w-1/4 min-w-fit shrink-0 pr-2 font-mono font-medium text-(--shiki-light) dark:text-(--shiki-dark)",
             deprecated && "line-through opacity-50"
           )}
         >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -145,10 +145,11 @@
 }
 
 @utility step {
-  @apply max-md:ml-11 max-md:-indent-11;
+  @apply max-md:pl-10;
   counter-increment: step;
+
   &::before {
-    @apply mr-4 inline-flex size-7 items-center justify-center rounded-lg border border-muted-foreground/15 bg-muted text-center text-sm font-medium text-muted-foreground ring-1 ring-line ring-offset-1 ring-offset-background max-md:-translate-y-px md:absolute md:-ml-11;
+    @apply absolute inline-flex size-6 items-center justify-center rounded-lg bg-muted text-center indent-0 text-[0.8125rem]/6 font-normal text-foreground max-md:left-0 md:-ml-10;
     content: counter(step);
   }
 }
@@ -486,7 +487,7 @@
     }
 
     [data-line] {
-      @apply py-0.5 pr-(--code-padding-right,0);
+      @apply pr-(--code-padding-right,0);
     }
   }
 


### PR DESCRIPTION
Remove showLineNumbers prop from ComponentSource components across documentation files to simplify code display. Update Steps component spacing, change code theme from github-dark to vesper, and adjust type table styling for better visual consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Code snippets across guides no longer show line numbers.

* **UI & Styling**
  * Footer attribution updated to include an additional reference.
  * Refined code block and step presentation, including adjusted headings, badges, spacing, and divider color for better readability.
  * Dark-mode syntax highlighting theme updated for improved contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->