### PR TITLE
refactor: replace WavesHorizontalIcon with Droplet for fluid gradient…

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,6 +1,7 @@
 import {
   BriefcaseBusinessIcon,
   CopyIcon,
+  Droplet,
   FileIcon,
   GalleryHorizontalEndIcon,
   LayoutGridIcon,
@@ -14,7 +15,6 @@ import {
   TerminalIcon,
   TerminalSquareIcon,
   VibrateIcon,
-  WavesHorizontalIcon,
   ZapIcon,
 } from "lucide-react"
 
@@ -855,7 +855,7 @@ export function ComponentIcon({ variant, ...props }: ComponentIconProps) {
     }
 
     case "fluid-gradient-text": {
-      return <WavesHorizontalIcon {...props} />
+      return <Droplet {...props} />
     }
 
     default: {

--- a/src/components/toc-minimap.tsx
+++ b/src/components/toc-minimap.tsx
@@ -42,7 +42,7 @@ export function TOCMinimap({ items }: { items: TOCItemType[] }) {
             delay={0}
             closeDelay={0}
             render={
-              <div className="flex max-h-[calc(100dvh-var(--doc-cols-top,0)+--spacing(-24))] flex-col gap-2 overflow-hidden py-3 pl-6 opacity-100 transition-opacity duration-200 data-popup-open:opacity-0">
+              <div className="flex max-h-[calc(100dvh-var(--doc-cols-top,0)+--spacing(-24))] flex-col gap-3 overflow-hidden py-3 pl-6 opacity-100 transition-opacity duration-200 data-popup-open:opacity-0">
                 {items.map((item) => (
                   <div
                     key={item.url}

--- a/src/features/doc/content/copy-button.mdx
+++ b/src/features/doc/content/copy-button.mdx
@@ -3,7 +3,6 @@ title: Copy Button
 description: Copy text to clipboard with visual, haptic, and audio feedback.
 image: https://assets.chanhdai.com/images/blog/copy-button.webp
 category: components
-updated: true
 createdAt: 2026-02-09
 updatedAt: 2026-04-20
 ---

--- a/src/registry/components/toc-minimap/toc-minimap.tsx
+++ b/src/registry/components/toc-minimap/toc-minimap.tsx
@@ -40,7 +40,7 @@ export function TOCMinimap({ items, className }: TOCMinimapProps) {
           delay={0}
           closeDelay={0}
           render={
-            <div className="flex max-h-[50dvh] flex-col gap-2 overflow-hidden py-3 pl-6 opacity-100 transition-opacity duration-200 data-popup-open:opacity-0">
+            <div className="flex max-h-[50dvh] flex-col gap-3 overflow-hidden py-3 pl-6 opacity-100 transition-opacity duration-200 data-popup-open:opacity-0">
               {items.map((item) => (
                 <div
                   key={item.url}


### PR DESCRIPTION
… text

style: increase gap spacing from 2 to 3 in TOC minimap components

docs: remove updated flag from copy button documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated icon for fluid-gradient-text variant.
  * Refined spacing in table of contents minimap hover marker for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->