### PR TITLE
style: apply dark mode liquid glass border styling across components

### DIFF
--- a/src/app/(app)/(pages)/components/component-item.tsx
+++ b/src/app/(app)/(pages)/components/component-item.tsx
@@ -31,6 +31,7 @@ export function ComponentItemIcon({
       className={cn(
         "relative flex size-6 shrink-0 items-center justify-center rounded-lg",
         "border border-muted-foreground/15 bg-muted ring-1 ring-line ring-offset-1 ring-offset-background",
+        "dark:liquid-glass-border dark:border-none",
         "[&_svg]:pointer-events-none [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
         className
       )}

--- a/src/components/code-collapsible-wrapper.tsx
+++ b/src/components/code-collapsible-wrapper.tsx
@@ -28,7 +28,11 @@ export function CodeCollapsibleWrapper({
 
       <div className="absolute inset-x-0 bottom-0 flex h-24 items-end justify-center bg-linear-to-t from-background from-[2rem] to-transparent group-data-[state=open]/collapsible:hidden">
         <CollapsibleTrigger asChild>
-          <Button variant="outline" size="sm">
+          <Button
+            variant="outline"
+            className="dark:liquid-glass-border dark:border-none"
+            size="sm"
+          >
             Expand
           </Button>
         </CollapsibleTrigger>

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -427,8 +427,8 @@ function CommandMenuTrigger({ ...props }: React.ComponentProps<typeof Button>) {
     <Button
       data-slot="command-menu-trigger"
       className={cn(
-        "gap-1.5 rounded-full bg-zinc-50 text-muted-foreground shadow-none select-none hover:bg-zinc-50 hover:text-muted-foreground dark:hover:bg-input/30",
-        "liquid-glass-border border-none"
+        "gap-1.5 rounded-full text-muted-foreground shadow-none select-none hover:bg-background hover:text-muted-foreground dark:hover:bg-input/30",
+        "dark:liquid-glass-border dark:border-none"
       )}
       variant="outline"
       size="sm"

--- a/src/features/portfolio/components/awards/award-item.tsx
+++ b/src/features/portfolio/components/awards/award-item.tsx
@@ -35,6 +35,7 @@ export function AwardItem({
         <div
           className={cn(
             "mx-4 flex size-6 shrink-0 items-center justify-center rounded-lg border border-muted-foreground/15 bg-muted ring-1 ring-line ring-offset-1 ring-offset-background",
+            "dark:liquid-glass-border dark:border-none",
             "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4"
           )}
         >

--- a/src/features/portfolio/components/bookmarks/bookmark-item.tsx
+++ b/src/features/portfolio/components/bookmarks/bookmark-item.tsx
@@ -25,6 +25,7 @@ export function BookmarkItem({
         className={cn(
           "mx-4 flex size-6 shrink-0 items-center justify-center rounded-lg select-none",
           "border border-muted-foreground/15 ring-1 ring-line ring-offset-1 ring-offset-background",
+          "dark:liquid-glass-border dark:border-none",
           "bg-muted text-muted-foreground [&_svg]:size-4"
         )}
       >

--- a/src/features/portfolio/components/certifications/certification-item.tsx
+++ b/src/features/portfolio/components/certifications/certification-item.tsx
@@ -38,6 +38,7 @@ export function CertificationItem({
           className={cn(
             "mx-4 flex size-6 shrink-0 items-center justify-center rounded-lg select-none",
             "border border-muted-foreground/15 ring-1 ring-line ring-offset-1 ring-offset-background",
+            "dark:liquid-glass-border dark:border-none",
             "bg-muted text-muted-foreground [&_svg]:size-4"
           )}
         >

--- a/src/features/portfolio/components/experiences/experience-position-item.tsx
+++ b/src/features/portfolio/components/experiences/experience-position-item.tsx
@@ -45,6 +45,7 @@ export function ExperiencePositionItem({
               "flex size-6 shrink-0 items-center justify-center rounded-lg",
               "bg-muted text-muted-foreground",
               "border border-muted-foreground/15 ring-1 ring-line ring-offset-1 ring-offset-background",
+              "dark:liquid-glass-border dark:border-none",
               "[&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
             )}
           >

--- a/src/features/portfolio/components/overview/intro-item.tsx
+++ b/src/features/portfolio/components/overview/intro-item.tsx
@@ -20,6 +20,7 @@ export function IntroItemIcon({
     <div
       className={cn(
         "flex size-6 shrink-0 items-center justify-center rounded-lg border border-muted-foreground/15 bg-muted ring-1 ring-line ring-offset-1 ring-offset-background",
+        "dark:liquid-glass-border dark:border-none",
         "[&_svg]:pointer-events-none [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
         className
       )}


### PR DESCRIPTION
Add dark:liquid-glass-border and dark:border-none classes to icons and buttons for consistent glass morphism effect in dark theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode styling across multiple UI components for improved visual consistency and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->