### PR TITLE
style: update code number color values to use simplified oklch format

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -284,9 +284,7 @@
 
   --code: var(--background);
   --code-foreground: var(--foreground);
-
-  /* zinc-400 */
-  --code-number: oklch(0.705 0.015 286.067);
+  --code-number: oklch(0.24 0.01 0 / 0.3);
 
   --code-highlight: oklch(0.9584 0.0013 286.37);
 
@@ -397,9 +395,7 @@
 
   --code: var(--background);
   --code-foreground: var(--foreground);
-
-  /* zinc-600 */
-  --code-number: oklch(44.2% 0.017 285.786);
+  --code-number: oklch(0.43 0 0);
 
   /* zinc-900 */
   --code-highlight: oklch(0.21 0.006 285.885);


### PR DESCRIPTION
Remove zinc color comments and replace with more concise oklch values for better color consistency across light and dark themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted color values for code display elements in light and dark theme modes to improve visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->