### PR TITLE
docs: remove c15t consent management references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ A minimal, pixel-perfect dev portfolio, shadcn registry, and blog to showcase my
 - Spam-protected email
 - Installable as PWA
 - Analytics with [PostHog](https://posthog.com) and [OpenPanel](https://openpanel.dev)
-- Consent management via [c15t](https://c15t.com)
 
 ### Content
 

--- a/src/features/doc/content/welcome.mdx
+++ b/src/features/doc/content/welcome.mdx
@@ -22,7 +22,6 @@ updatedAt: 2026-03-26
 - Spam-protected email
 - Installable as PWA
 - Analytics with [PostHog](https://posthog.com) and [OpenPanel](https://openpanel.dev)
-- Consent management via [c15t](https://c15t.com)
 
 ## Content
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed "Consent management via c15t" feature reference from README and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->