### PR TITLE
feat: improve code block copy button UX with hover interactions

### DIFF
--- a/src/components/component-preview.tsx
+++ b/src/components/component-preview.tsx
@@ -173,7 +173,7 @@ export function ComponentPreview({
           value="code"
           className={cn(
             "**:data-rehype-pretty-code-figure:m-0 **:data-rehype-pretty-code-figure:pt-0",
-            "**:data-[slot=copy-button]:top-1",
+            "**:data-[slot=copy-button]:top-1 **:data-[slot=copy-button]:opacity-100",
             "**:data-fade-overlay:top-px"
           )}
         >

--- a/src/components/mdx-code-block.tsx
+++ b/src/components/mdx-code-block.tsx
@@ -61,7 +61,7 @@ export const mdxCodeBlockComponents = {
 
     return (
       <>
-        <div className="rounded-[9px] border bg-code">
+        <div className="group/pre rounded-[9px] border bg-code">
           <pre
             className={cn(
               __rawString__ && !__withMeta__ && "[--code-padding-right:6rem]",
@@ -69,36 +69,37 @@ export const mdxCodeBlockComponents = {
             )}
             {...props}
           />
-        </div>
 
-        {__rawString__ && (
-          <>
-            <CopyButton
-              data-slot="copy-button"
-              className={cn(
-                "absolute top-2 right-2 z-10 size-7 rounded-[5px] border-none text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
-                __withMeta__ && "top-1.5 right-1.5 rounded-md"
-              )}
-              variant="ghost"
-              size="icon-xs"
-              text={__rawString__}
-              event="copy_code_block"
-            />
-
-            {!__withMeta__ && (
-              <div
-                aria-hidden
-                data-fade-overlay
-                className="top-1.25 right-1.25"
-                style={
-                  {
-                    "--fade-color": "var(--code)",
-                  } as React.CSSProperties
-                }
+          {__rawString__ && (
+            <>
+              <CopyButton
+                data-slot="copy-button"
+                className={cn(
+                  "absolute top-2 right-2 z-10 size-7 rounded-[5px] border-none text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
+                  __withMeta__ && "top-1.5 right-1.5 rounded-md",
+                  !__withMeta__ && "opacity-0 group-hover/pre:opacity-100"
+                )}
+                variant="ghost"
+                size="icon-xs"
+                text={__rawString__}
+                event="copy_code_block"
               />
-            )}
-          </>
-        )}
+
+              {!__withMeta__ && (
+                <div
+                  aria-hidden
+                  data-fade-overlay
+                  className="top-1.25 right-1.25"
+                  style={
+                    {
+                      "--fade-color": "var(--code)",
+                    } as React.CSSProperties
+                  }
+                />
+              )}
+            </>
+          )}
+        </div>
       </>
     )
   },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -486,7 +486,7 @@
     @apply has-data-[slot=code-block-command]:pt-0;
 
     pre {
-      @apply no-scrollbar overflow-x-auto overscroll-x-contain p-4 has-data-line-numbers:px-0;
+      @apply no-scrollbar overflow-x-auto overscroll-x-contain p-4 outline-none has-data-line-numbers:px-0;
     }
 
     code {


### PR DESCRIPTION
Add group hover functionality to code blocks and hide copy button by default, showing it only on hover for cleaner interface. Override opacity in component preview to keep button always visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Copy buttons in code blocks now intelligently appear on hover instead of remaining constantly visible, creating a cleaner interface
  * Code block styling refinements including outline handling and padding adjustments for improved visual presentation
  * Enhanced styling consistency across code preview and code block components throughout the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->