### PR TITLE
feat: add components showcase page with grid layout and demo components

### DIFF
--- a/src/__registry__/index.tsx
+++ b/src/__registry__/index.tsx
@@ -790,6 +790,23 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
+  "apple-hello-effect-languages-demo": {
+    name: "apple-hello-effect-languages-demo",
+    description: "",
+    type: "registry:example",
+    files: [{
+      path: "src/registry/examples/apple-hello-effect-languages-demo.tsx",
+      type: "registry:example",
+      target: "",
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/apple-hello-effect-languages-demo.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
   "theme-switcher-demo": {
     name: "theme-switcher-demo",
     description: "",

--- a/src/app/(app)/(showcase)/components/showcase/page.tsx
+++ b/src/app/(app)/(showcase)/components/showcase/page.tsx
@@ -1,0 +1,189 @@
+import type { Metadata } from "next"
+
+import {
+  PageHeading,
+  PageHeadingTagline,
+  PageHeadingTitle,
+} from "@/components/page-heading"
+import { X_HANDLE } from "@/config/site"
+import { cn } from "@/lib/utils"
+import AppleHelloEffectAllDemo from "@/registry/examples/apple-hello-effect-languages-demo"
+import CodeBlockCommandDemo from "@/registry/examples/code-block-command-demo"
+import CopyButtonDemo from "@/registry/examples/copy-button-demo"
+import ElasticSliderDemo from "@/registry/examples/elastic-slider-demo"
+import FluidGradientTextDemo from "@/registry/examples/fluid-gradient-text-demo-01"
+import GitHubContributionsDemo from "@/registry/examples/github-contributions-demo"
+import GitHubStarsDemo from "@/registry/examples/github-stars-demo"
+import GlowCardGridDemo01 from "@/registry/examples/glow-card-grid-demo-01"
+import HapticDemo from "@/registry/examples/haptic-demo"
+import MiddleTruncationDemo from "@/registry/examples/middle-truncation-demo"
+import ScrollFadeEffectDemo from "@/registry/examples/scroll-fade-effect-demo-01"
+import ShimmeringTextDemo2 from "@/registry/examples/shimmering-text-demo-02"
+import SlideToUnlockDemo1 from "@/registry/examples/slide-to-unlock-demo-01"
+import TestimonialSpotlightDemo from "@/registry/examples/testimonial-spotlight-demo-01"
+import TestimonialsMarqueeDemo1 from "@/registry/examples/testimonials-marquee-demo-01"
+import TextFlipDemo from "@/registry/examples/text-flip-demo"
+import ThemeSwitcherDemo from "@/registry/examples/theme-switcher-demo"
+import ThemeToggleEffectDemo from "@/registry/examples/theme-toggle-effect-demo/theme-toggle-effect-demo"
+import TOCMinimapDemo from "@/registry/examples/toc-minimap-demo"
+import TwemojiDemo from "@/registry/examples/twemoji-demo"
+import WheelPickerDemo from "@/registry/examples/wheel-picker-demo"
+import WorkExperienceDemo from "@/registry/examples/work-experience-demo"
+
+import { RemountOnThemeChange } from "./remount-on-theme-change"
+
+const title = "Components"
+const description = "Pixel-perfect, uniquely crafted."
+
+const ogImage = `/og/simple?title=${encodeURIComponent(title)}&description=${encodeURIComponent(description)}`
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: "/components",
+  },
+  openGraph: {
+    url: "/components",
+    type: "website",
+    images: {
+      url: ogImage,
+      width: 1200,
+      height: 630,
+      alt: title,
+    },
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: X_HANDLE,
+    creator: X_HANDLE,
+    images: [ogImage],
+  },
+}
+
+export default function ComponentsShowcasePage() {
+  return (
+    <div>
+      <PageHeading>
+        <PageHeadingTagline>Components</PageHeadingTagline>
+        <PageHeadingTitle>Pixel-perfect, uniquely crafted.</PageHeadingTitle>
+      </PageHeading>
+
+      <div className="h-4" />
+
+      <div className="screen-line-bottom h-px" />
+
+      <div className="grid grid-cols-1 gap-1 p-1 md:grid-cols-3">
+        <GridItem className="md:row-span-2">
+          <AppleHelloEffectAllDemo />
+        </GridItem>
+
+        <GridItem>
+          <RemountOnThemeChange>
+            <SlideToUnlockDemo1 />
+          </RemountOnThemeChange>
+        </GridItem>
+
+        <GridItem>
+          <ThemeSwitcherDemo />
+        </GridItem>
+
+        <GridItem className="md:row-span-2">
+          <ElasticSliderDemo />
+        </GridItem>
+
+        <GridItem>
+          <div className="flex min-h-12 items-center">
+            <ThemeToggleEffectDemo />
+          </div>
+        </GridItem>
+
+        <GridItem className="**:data-rwp-wrapper:rounded-xl md:row-span-2">
+          <WheelPickerDemo />
+        </GridItem>
+
+        <GridItem className="md:row-span-2">
+          <MiddleTruncationDemo />
+        </GridItem>
+
+        <GridItem>
+          <TestimonialSpotlightDemo />
+        </GridItem>
+
+        <GridItem className="md:col-span-2 md:row-span-2">
+          <GitHubContributionsDemo />
+        </GridItem>
+
+        <GridItem>
+          <TextFlipDemo />
+        </GridItem>
+
+        <GridItem>
+          <CopyButtonDemo />
+        </GridItem>
+
+        <GridItem>
+          <TwemojiDemo />
+        </GridItem>
+
+        <GridItem className="p-0 pb-4 md:col-span-2 md:row-span-2">
+          <FluidGradientTextDemo />
+        </GridItem>
+
+        <GridItem>
+          <ShimmeringTextDemo2 />
+        </GridItem>
+
+        <GridItem className="overflow-hidden p-0 **:data-[slot=marquee]:border-none md:col-span-3">
+          <TestimonialsMarqueeDemo1 />
+        </GridItem>
+
+        <GridItem className="p-0 md:col-span-2 md:row-span-2">
+          <GlowCardGridDemo01 />
+        </GridItem>
+
+        <GridItem>
+          <GitHubStarsDemo />
+        </GridItem>
+
+        <GridItem className="**:data-[slot=scroll-fade-effect-demo]:rounded-xl">
+          <ScrollFadeEffectDemo />
+        </GridItem>
+
+        <GridItem className="[--code:var(--surface)] md:col-span-2">
+          <CodeBlockCommandDemo />
+        </GridItem>
+
+        <GridItem className="px-0 md:col-span-1">
+          <TOCMinimapDemo />
+        </GridItem>
+
+        <GridItem className="px-0 md:col-span-2">
+          <WorkExperienceDemo />
+        </GridItem>
+
+        <GridItem>
+          <HapticDemo />
+        </GridItem>
+      </div>
+    </div>
+  )
+}
+
+function GridItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center rounded-lg border border-line bg-background p-4 transition-[border-color] hover:border-border",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/app/(app)/(showcase)/components/showcase/remount-on-theme-change.tsx
+++ b/src/app/(app)/(showcase)/components/showcase/remount-on-theme-change.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import { useTheme } from "next-themes"
+
+export function RemountOnThemeChange(props: React.ComponentProps<"div">) {
+  const { resolvedTheme } = useTheme()
+
+  return <div key={resolvedTheme} {...props} />
+}

--- a/src/app/(app)/(showcase)/layout.tsx
+++ b/src/app/(app)/(showcase)/layout.tsx
@@ -1,0 +1,14 @@
+export default function AppLayoutWide({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="layout-wide"
+      className="container mx-auto border-x border-line pt-12"
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/features/doc/content/apple-hello-effect.mdx
+++ b/src/features/doc/content/apple-hello-effect.mdx
@@ -9,29 +9,8 @@ updatedAt: 2026-04-05
 
 <ComponentPreview
   className="text-foreground"
-  name="apple-hello-effect-english-demo"
+  name="apple-hello-effect-languages-demo"
   openInV0Url="https://chanhdai.com/r/apple-hello-effect.json"
-  canReplay
-/>
-
-<ComponentPreview
-  className="text-foreground"
-  name="apple-hello-effect-hindi-demo"
-  openInV0Url="https://chanhdai.com/r/apple-hello-effect-hindi.json"
-  canReplay
-/>
-
-<ComponentPreview
-  className="text-foreground"
-  name="apple-hello-effect-spanish-demo"
-  openInV0Url="https://chanhdai.com/r/apple-hello-effect-spanish.json"
-  canReplay
-/>
-
-<ComponentPreview
-  className="text-foreground"
-  name="apple-hello-effect-vietnamese-demo"
-  openInV0Url="https://chanhdai.com/r/apple-hello-effect-vietnamese.json"
   canReplay
 />
 

--- a/src/registry/examples/_registry.ts
+++ b/src/registry/examples/_registry.ts
@@ -59,6 +59,22 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "apple-hello-effect-languages-demo",
+    type: "registry:example",
+    registryDependencies: [
+      getRegistryItemUrl("apple-hello-effect-english"),
+      getRegistryItemUrl("apple-hello-effect-hindi"),
+      getRegistryItemUrl("apple-hello-effect-spanish"),
+      getRegistryItemUrl("apple-hello-effect-vietnamese"),
+    ],
+    files: [
+      {
+        path: "examples/apple-hello-effect-languages-demo.tsx",
+        type: "registry:example",
+      },
+    ],
+  },
+  {
     name: "theme-switcher-demo",
     type: "registry:example",
     registryDependencies: [getRegistryItemUrl("theme-switcher")],

--- a/src/registry/examples/apple-hello-effect-languages-demo.tsx
+++ b/src/registry/examples/apple-hello-effect-languages-demo.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { AnimatePresence } from "motion/react"
+import { useState } from "react"
+
+import { AppleHelloEffectEnglish } from "@/registry/components/apple-hello-effect/apple-hello-effect-english"
+import { AppleHelloEffectHindi } from "@/registry/components/apple-hello-effect/apple-hello-effect-hindi"
+import { AppleHelloEffectSpanish } from "@/registry/components/apple-hello-effect/apple-hello-effect-spanish"
+import { AppleHelloEffectVietnamese } from "@/registry/components/apple-hello-effect/apple-hello-effect-vietnamese"
+
+export default function AppleHelloEffectLanguagesDemo() {
+  const [index, setIndex] = useState(0)
+
+  const handleAnimationEnd = () => {
+    setIndex((prevIndex) => (prevIndex + 1) % 4)
+  }
+
+  const demos = [
+    <AppleHelloEffectEnglish
+      key="english"
+      onAnimationComplete={handleAnimationEnd}
+    />,
+    <AppleHelloEffectHindi
+      key="hindi"
+      onAnimationComplete={handleAnimationEnd}
+    />,
+    <AppleHelloEffectSpanish
+      key="spanish"
+      durationScale={0.8}
+      onAnimationComplete={handleAnimationEnd}
+    />,
+    <AppleHelloEffectVietnamese
+      key="vietnamese"
+      durationScale={0.8}
+      onAnimationComplete={handleAnimationEnd}
+    />,
+  ]
+
+  return <AnimatePresence mode="wait">{demos[index]}</AnimatePresence>
+}

--- a/src/registry/examples/scroll-fade-effect-demo-01.tsx
+++ b/src/registry/examples/scroll-fade-effect-demo-01.tsx
@@ -9,7 +9,7 @@ const tags = Array.from({ length: 50 }).map(
 
 export default function ScrollFadeEffectDemo() {
   return (
-    <div className="rounded-lg border">
+    <div data-slot="scroll-fade-effect-demo" className="rounded-lg border">
       <ScrollFadeEffect className="h-72 w-48">
         <div className="p-4">
           <h4 className="mb-4 text-sm leading-none font-medium">Tags</h4>

--- a/src/registry/examples/testimonials-marquee-demo-01.tsx
+++ b/src/registry/examples/testimonials-marquee-demo-01.tsx
@@ -18,7 +18,10 @@ import {
 export default function TestimonialsMarqueeDemo1() {
   return (
     <div className="w-full bg-background">
-      <Marquee className="border-y border-line [&_.rfm-initial-child-container]:items-stretch! [&_.rfm-marquee]:items-stretch!">
+      <Marquee
+        data-slot="marquee"
+        className="border-y border-line [&_.rfm-initial-child-container]:items-stretch! [&_.rfm-marquee]:items-stretch!"
+      >
         <MarqueeFade side="left" />
         <MarqueeFade side="right" />
 


### PR DESCRIPTION
Add new showcase page displaying component demos in responsive grid layout. Include RemountOnThemeChange utility for theme-dependent components and register apple-hello-effect-languages-demo component that cycles through multiple language variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Components showcase page featuring a responsive grid of interactive component demos.
  * Introduced a multi-language Apple Hello Effect demo that cycles through English, Hindi, Spanish, and Vietnamese translations.

* **Documentation**
  * Updated component documentation to reference the new consolidated language demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->