### PR TITLE
fix: remove padding from GitHub contributions demo grid item

### DIFF
--- a/src/app/(app)/(showcase)/components/showcase/page.tsx
+++ b/src/app/(app)/(showcase)/components/showcase/page.tsx
@@ -109,7 +109,7 @@ export default function ComponentsShowcasePage() {
           <TestimonialSpotlightDemo />
         </GridItem>
 
-        <GridItem className="md:col-span-2 md:row-span-2">
+        <GridItem className="p-0 md:col-span-2 md:row-span-2">
           <GitHubContributionsDemo />
         </GridItem>
 

--- a/src/features/portfolio/components/components-showcase.tsx
+++ b/src/features/portfolio/components/components-showcase.tsx
@@ -71,7 +71,7 @@ export function ComponentsShowcase() {
           <TestimonialSpotlightDemo />
         </GridItem>
 
-        <GridItem className="md:col-span-2 md:row-span-2">
+        <GridItem className="p-0 md:col-span-2 md:row-span-2">
           <GitHubContributionsDemo />
         </GridItem>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed default padding from showcase grid items to create a more compact visual layout in the portfolio display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->