### PR TITLE
feat: add navigation buttons between components and showcase pages

### DIFF
--- a/src/app/(app)/(pages)/components/page.tsx
+++ b/src/app/(app)/(pages)/components/page.tsx
@@ -1,5 +1,6 @@
-import { PlusIcon } from "lucide-react"
+import { Grip, LayoutDashboard, PlusIcon } from "lucide-react"
 import type { Metadata } from "next"
+import Link from "next/link"
 
 import { Button } from "@/components/base/ui/button"
 import {
@@ -127,6 +128,24 @@ export default function Page() {
       </div>
 
       <Separator />
+
+      <div className="screen-line-bottom h-px" />
+
+      <div className="flex items-center justify-end gap-1.5 p-1.5">
+        <Button className="size-7" variant="outline" size="icon-sm">
+          <Grip />
+        </Button>
+
+        <Button
+          className="size-7 border-none text-muted-foreground"
+          variant="ghost"
+          size="icon-sm"
+          nativeButton={false}
+          render={<Link href="/components/showcase" />}
+        >
+          <LayoutDashboard />
+        </Button>
+      </div>
 
       <div className="screen-line-bottom h-px" />
 

--- a/src/app/(app)/(showcase)/components/showcase/page.tsx
+++ b/src/app/(app)/(showcase)/components/showcase/page.tsx
@@ -1,5 +1,8 @@
+import { Grip, LayoutDashboard } from "lucide-react"
 import type { Metadata } from "next"
+import Link from "next/link"
 
+import { Button } from "@/components/base/ui/button"
 import {
   PageHeading,
   PageHeadingTagline,
@@ -68,7 +71,21 @@ export default function ComponentsShowcasePage() {
         <PageHeadingTitle>Pixel-perfect, uniquely crafted.</PageHeadingTitle>
       </PageHeading>
 
-      <div className="h-4" />
+      <div className="flex items-center justify-end gap-1 p-1">
+        <Button
+          className="size-7 border-none text-muted-foreground"
+          variant="ghost"
+          size="icon-sm"
+          nativeButton={false}
+          render={<Link href="/components" />}
+        >
+          <Grip />
+        </Button>
+
+        <Button className="size-7" variant="outline" size="icon-sm">
+          <LayoutDashboard />
+        </Button>
+      </div>
 
       <div className="screen-line-bottom h-px" />
 


### PR DESCRIPTION
Add Grip and LayoutDashboard icon buttons to allow users to switch between the components page and showcase page for better navigation experience

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation controls to component pages enabling users to seamlessly switch between component showcase and component management views
  * New icon buttons positioned in the header area for improved accessibility and layout flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->