### PR TITLE
refactor: update page title from "Components" to "Component Showcase"

### DIFF
--- a/src/app/(app)/(showcase)/components/showcase/page.tsx
+++ b/src/app/(app)/(showcase)/components/showcase/page.tsx
@@ -39,7 +39,7 @@ import TwemojiDemo from "@/registry/examples/twemoji-demo"
 import WheelPickerDemo from "@/registry/examples/wheel-picker-demo"
 import WorkExperienceDemo from "@/registry/examples/work-experience-demo"
 
-const title = "Components"
+const title = "Component Showcase"
 const description = "Pixel-perfect, uniquely crafted."
 
 const ogImage = `/og/simple?title=${encodeURIComponent(title)}&description=${encodeURIComponent(description)}`
@@ -48,10 +48,10 @@ export const metadata: Metadata = {
   title,
   description,
   alternates: {
-    canonical: "/components",
+    canonical: "/components/showcase",
   },
   openGraph: {
-    url: "/components",
+    url: "/components/showcase",
     type: "website",
     images: {
       url: ogImage,
@@ -72,7 +72,7 @@ export default function ComponentsShowcasePage() {
   return (
     <>
       <PageHeading>
-        <PageHeadingTagline>Components</PageHeadingTagline>
+        <PageHeadingTagline>Component Showcase</PageHeadingTagline>
         <PageHeadingTitle>Pixel-perfect, uniquely crafted.</PageHeadingTitle>
       </PageHeading>
 


### PR DESCRIPTION
Update page metadata and heading to use more descriptive title "Component Showcase" instead of generic "Components" for better clarity and SEO optimization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Rebranded showcase page to "Component Showcase" with updated page titles, headings, and metadata references
  * Applied enhanced styling to component preview elements, including improved rounded border effects
  * Standardized navigation paths and social metadata for consistency across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->