### PR TITLE
feat: add alias normalization for registry file targets

### DIFF
--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -154,9 +154,35 @@ function getFileTarget(file: z.infer<typeof registryItemFileSchema>) {
     if (file.type === "registry:lib") {
       target = `lib/${fileName}`
     }
+
+    return target ?? ""
   }
 
-  return target ?? ""
+  return normalizeAliasTarget(target)
+}
+
+function normalizeAliasTarget(target: string) {
+  const regex = /^@(components|ui|hooks|lib)\/(.+)$/
+
+  return target.replace(regex, (_, type, rest) => {
+    if (type === "components") {
+      return `components/${rest}`
+    }
+
+    if (type === "ui") {
+      return `components/ui/${rest}`
+    }
+
+    if (type === "hooks") {
+      return `hooks/${rest}`
+    }
+
+    if (type === "lib") {
+      return `lib/${rest}`
+    }
+
+    return target
+  })
 }
 
 export type FileTree = {


### PR DESCRIPTION
Add normalizeAliasTarget function to convert [@]components, [@]ui, [@]hooks, and [@]lib aliases to their corresponding directory paths, enabling cleaner import statements in registry files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal target resolution and alias path normalization for more consistent handling of library imports and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->