### PR TITLE
style: adjust profile cover aspect ratios and logo sizing

### DIFF
--- a/src/features/portfolio/components/profile-cover.tsx
+++ b/src/features/portfolio/components/profile-cover.tsx
@@ -15,8 +15,8 @@ export function ProfileCover() {
       <div
         ref={containerRef}
         className={cn(
-          "aspect-2/1 border-x border-line select-none sm:aspect-3/1",
-          "flex items-center justify-center text-black dark:text-white",
+          "aspect-2.5/1 border-x border-line select-none sm:aspect-3.5/1",
+          "flex items-center justify-center",
           "screen-line-top screen-line-bottom before:-top-px after:-bottom-px",
           "bg-black/0.75 bg-[radial-gradient(var(--pattern-foreground)_1px,transparent_0)] bg-size-[10px_10px] bg-center [--pattern-foreground:var(--color-zinc-950)]/5 dark:bg-white/0.75 dark:[--pattern-foreground:var(--color-white)]/5"
         )}
@@ -24,7 +24,7 @@ export function ProfileCover() {
         <Magnet containerRef={containerRef} magnetStrength={6}>
           <ChanhDaiMark
             id="js-cover-mark"
-            className="h-14 w-28 sm:h-16 sm:w-32"
+            className="h-12 w-24 min-[25rem]:h-14 min-[25rem]:w-28 sm:h-16 sm:w-32"
           />
         </Magnet>
       </div>


### PR DESCRIPTION
Update aspect ratios from 2/1 to 2.5/1 and 3/1 to 3.5/1 for better visual proportions. Add responsive breakpoint at 25rem for logo sizing and remove redundant text color classes.