### PR TITLE
refactor: extract mobile navigation to separate SiteBottomNav component

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,6 @@
 import dynamic from "next/dynamic"
 
+import { SiteBottomNav } from "@/components/site-bottom-nav"
 import { SiteFooter } from "@/components/site-footer"
 import { SiteHeader } from "@/components/site-header"
 
@@ -13,6 +14,11 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       <SiteHeader />
       <main className="max-w-screen overflow-x-clip px-2">{children}</main>
       <SiteFooter />
+      <div
+        className="pointer-events-none fixed inset-x-0 bottom-0 z-50 h-[calc(--spacing(24)+env(safe-area-inset-bottom,0))] bg-linear-to-b from-transparent from-[calc(env(safe-area-inset-bottom,0%))] to-background mask-linear-[to_top,var(--background)_25%,transparent] backdrop-blur-[1px]"
+        aria-hidden
+      />
+      <SiteBottomNav />
       <ScrollToTop />
     </div>
   )

--- a/src/components/nav-mobile.tsx
+++ b/src/components/nav-mobile.tsx
@@ -74,7 +74,7 @@ function NavMobileTrigger(
 ) {
   return (
     <Button
-      className="group relative flex touch-manipulation flex-col gap-1 border-none before:absolute before:-inset-x-2 before:-top-8 before:-bottom-1 active:scale-none data-open:bg-accent"
+      className="group relative flex touch-manipulation flex-col gap-1 border-none before:absolute before:-inset-x-2 before:-top-8 before:-bottom-1 active:scale-none aria-expanded:bg-accent"
       variant="ghost"
       size="icon-sm"
       aria-label="Toggle Menu"

--- a/src/components/scroll-to-top.tsx
+++ b/src/components/scroll-to-top.tsx
@@ -29,7 +29,7 @@ export function ScrollToTop({
       data-visible={visible}
       data-scroll-direction={scrollDirection}
       className={cn(
-        "[--bottom:0.5rem] lg:[--bottom:2rem]",
+        "[--bottom:0.5rem] sm:[--bottom:1rem] lg:[--bottom:2rem]",
         "fixed right-4 bottom-[calc(var(--bottom,0.5rem)+env(safe-area-inset-bottom,0))] z-50 lg:right-8",
         "transition-[background-color,opacity] duration-300 data-[scroll-direction=down]:opacity-30 data-[scroll-direction=up]:opacity-100 data-[visible=false]:opacity-0",
         "data-[scroll-direction=down]:hover:opacity-100",

--- a/src/components/site-bottom-nav.tsx
+++ b/src/components/site-bottom-nav.tsx
@@ -1,0 +1,44 @@
+import dynamic from "next/dynamic"
+
+import blocks from "@/__registry__/__blocks__.json"
+import { Separator } from "@/components/ui/separator"
+import { MOBILE_NAV } from "@/config/site"
+import { getAllDocs } from "@/features/doc/data/documents"
+import type { DocPreview } from "@/features/doc/types/document"
+import { cn } from "@/lib/utils"
+
+const CommandMenu = dynamic(() =>
+  import("@/components/command-menu").then((mod) => mod.CommandMenu)
+)
+
+const NavMobile = dynamic(() =>
+  import("@/components/nav-mobile").then((mod) => mod.NavMobile)
+)
+
+export function SiteBottomNav() {
+  const docs = getAllDocs()
+
+  // Minimize data serialized to client component - only send necessary fields
+  const docPreviews: DocPreview[] = docs.map((doc) => ({
+    slug: doc.slug,
+    title: doc.metadata.title,
+    category: doc.metadata.category,
+  }))
+
+  return (
+    <div
+      className={cn(
+        "fixed! bottom-[calc(--spacing(2)+env(safe-area-inset-bottom,0))] left-1/2 z-50 flex w-fit -translate-x-1/2 items-center rounded-xl bg-popover py-1 pr-1 pl-2.5 shadow-md ring ring-foreground/10 sm:hidden dark:ring-foreground/20",
+        "dark:liquid-glass-border dark:ring-0",
+        "*:data-[slot=command-menu-trigger]:min-w-20 *:data-[slot=command-menu-trigger]:gap-2 *:data-[slot=command-menu-trigger]:rounded-none *:data-[slot=command-menu-trigger]:border-none *:data-[slot=command-menu-trigger]:bg-transparent *:data-[slot=command-menu-trigger]:px-0 *:data-[slot=command-menu-trigger]:liquid-glass-border-none *:data-[slot=command-menu-trigger]:hover:bg-transparent *:data-[slot=command-menu-trigger]:active:scale-none"
+      )}
+    >
+      <CommandMenu docs={docPreviews} blocks={blocks} />
+      <Separator
+        orientation="vertical"
+        className="mr-1 ml-2.5 data-vertical:h-6 data-vertical:self-center"
+      />
+      <NavMobile items={MOBILE_NAV} />
+    </div>
+  )
+}

--- a/src/components/site-footer-brand.tsx
+++ b/src/components/site-footer-brand.tsx
@@ -30,7 +30,7 @@ export function SiteFooterInteractiveLogotype() {
   }
 
   return (
-    <div className="screen-line-bottom after:z-1 after:bg-foreground/10">
+    <div className="screen-line-bottom after:z-1 after:bg-foreground/15">
       <div
         className="overflow-hidden"
         onMouseMove={handleMouseMove}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -121,7 +121,7 @@ export function SiteFooter() {
       <SiteFooterInteractiveLogotype />
 
       <div className="pb-[env(safe-area-inset-bottom,0px)]">
-        <div className="flex h-16 sm:h-2" />
+        <div className="flex h-24" />
       </div>
     </footer>
   )

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -7,10 +7,9 @@ import { NavItemGitHub } from "@/components/nav-item-github"
 import { SiteHeaderMark } from "@/components/site-header-mark"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { Separator } from "@/components/ui/separator"
-import { MAIN_NAV, MOBILE_NAV } from "@/config/site"
+import { MAIN_NAV } from "@/config/site"
 import { getAllDocs } from "@/features/doc/data/documents"
 import type { DocPreview } from "@/features/doc/types/document"
-import { cn } from "@/lib/utils"
 
 const BrandContextMenu = dynamic(() =>
   import("@/components/brand-context-menu").then((mod) => mod.BrandContextMenu)
@@ -18,10 +17,6 @@ const BrandContextMenu = dynamic(() =>
 
 const CommandMenu = dynamic(() =>
   import("@/components/command-menu").then((mod) => mod.CommandMenu)
-)
-
-const NavMobile = dynamic(() =>
-  import("@/components/nav-mobile").then((mod) => mod.NavMobile)
 )
 
 export function SiteHeader() {
@@ -35,54 +30,35 @@ export function SiteHeader() {
   }))
 
   return (
-    <>
-      <header className="sticky top-0 z-50 max-w-screen overflow-x-hidden bg-background px-2 pt-2">
-        <div className="screen-line-top screen-line-bottom mx-auto flex h-12 items-center justify-between gap-2 border-x border-line px-2 group-has-data-[slot=layout-wide]/layout:container after:z-1 after:transition-[background-color] sm:gap-4 md:max-w-3xl">
-          <BrandContextMenu>
-            <Link
-              className="transition-[scale] ease-out active:scale-[0.98] has-data-[visible=false]:pointer-events-none [&_svg]:h-8 [&_svg]:shrink-0"
-              href="/"
-              aria-label="Home"
-            >
-              <SiteHeaderMark />
-            </Link>
-          </BrandContextMenu>
+    <header className="sticky top-0 z-50 max-w-screen overflow-x-hidden bg-background px-2 pt-2">
+      <div className="screen-line-top screen-line-bottom mx-auto flex h-12 items-center justify-between gap-2 border-x border-line px-2 group-has-data-[slot=layout-wide]/layout:container after:z-1 after:transition-[background-color] sm:gap-4 md:max-w-3xl">
+        <BrandContextMenu>
+          <Link
+            className="transition-[scale] ease-out active:scale-[0.98] has-data-[visible=false]:pointer-events-none [&_svg]:h-8 [&_svg]:shrink-0"
+            href="/"
+            aria-label="Home"
+          >
+            <SiteHeaderMark />
+          </Link>
+        </BrandContextMenu>
 
-          <div className="flex-1" />
+        <div className="flex-1" />
 
-          <NavDesktop items={MAIN_NAV} />
+        <NavDesktop items={MAIN_NAV} />
 
-          <div className="flex items-center *:first:mr-2 max-sm:*:data-[slot=command-menu-trigger]:hidden">
-            <CommandMenu docs={docPreviews} blocks={blocks} enabledHotkeys />
-            <NavItemGitHub />
-            <Separator
-              orientation="vertical"
-              className="mx-2 data-vertical:h-4 data-vertical:self-center"
-            />
-            <ThemeToggle />
-          </div>
-
-          {/* <div className="absolute top-[-3.5px] left-[-4.5px] z-2 flex size-2 border border-line bg-background" /> */}
-          {/* <div className="absolute top-[-3.5px] right-[-4.5px] z-2 flex size-2 border border-line bg-background" /> */}
+        <div className="flex items-center *:first:mr-2 max-sm:*:data-[slot=command-menu-trigger]:hidden">
+          <CommandMenu docs={docPreviews} blocks={blocks} enabledHotkeys />
+          <NavItemGitHub />
+          <Separator
+            orientation="vertical"
+            className="mx-2 data-vertical:h-4 data-vertical:self-center"
+          />
+          <ThemeToggle />
         </div>
-      </header>
 
-      {/* Nav Mobile */}
-      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 h-[calc(--spacing(24)+env(safe-area-inset-bottom,0))] bg-linear-to-b from-transparent from-[calc(env(safe-area-inset-bottom,0%))] to-background mask-linear-[to_top,var(--background)_25%,transparent] backdrop-blur-[1px] sm:hidden" />
-      <div
-        className={cn(
-          "fixed! bottom-[calc(--spacing(2)+env(safe-area-inset-bottom,0))] left-1/2 z-50 flex w-fit -translate-x-1/2 items-center rounded-xl bg-popover py-1 pr-1 pl-2.5 shadow-md ring ring-foreground/10 sm:hidden dark:ring-foreground/20",
-          "dark:liquid-glass-border dark:ring-0",
-          "*:data-[slot=command-menu-trigger]:min-w-20 *:data-[slot=command-menu-trigger]:gap-2 *:data-[slot=command-menu-trigger]:rounded-none *:data-[slot=command-menu-trigger]:border-none *:data-[slot=command-menu-trigger]:bg-transparent *:data-[slot=command-menu-trigger]:px-0 *:data-[slot=command-menu-trigger]:liquid-glass-border-none *:data-[slot=command-menu-trigger]:hover:bg-transparent *:data-[slot=command-menu-trigger]:active:scale-none"
-        )}
-      >
-        <CommandMenu docs={docPreviews} blocks={blocks} />
-        <Separator
-          orientation="vertical"
-          className="mr-1 ml-2.5 data-vertical:h-6 data-vertical:self-center"
-        />
-        <NavMobile items={MOBILE_NAV} />
+        {/* <div className="absolute top-[-3.5px] left-[-4.5px] z-2 flex size-2 border border-line bg-background" /> */}
+        {/* <div className="absolute top-[-3.5px] right-[-4.5px] z-2 flex size-2 border border-line bg-background" /> */}
       </div>
-    </>
+    </header>
   )
 }


### PR DESCRIPTION
Move mobile navigation from SiteHeader to dedicated SiteBottomNav component to improve code organization and separation of concerns. Update styling for better mobile experience and adjust scroll-to-top positioning to accommodate bottom navigation.