### PR TITLE
refactor: update typography and UI styling across components

### DIFF
--- a/src/app/(app)/(pages)/sponsors/page.tsx
+++ b/src/app/(app)/(pages)/sponsors/page.tsx
@@ -110,7 +110,7 @@ function SponsorsGroup({
 
   return (
     <div>
-      <h2 className="p-4 font-pixel text-sm/none font-medium text-muted-foreground uppercase">
+      <h2 className="p-4 font-heading text-xl/none font-medium tracking-tight">
         {title}
       </h2>
 

--- a/src/app/(preview)/components/block-viewer.tsx
+++ b/src/app/(preview)/components/block-viewer.tsx
@@ -328,7 +328,7 @@ function BlockViewerToolbar() {
         />
 
         <Button
-          className="w-fit gap-1.5 px-2 font-mono text-[0.8125rem] shadow-none will-change-transform active:scale-none [&_svg]:text-muted-foreground"
+          className="w-fit gap-1.5 px-2 font-mono text-[0.8125rem] font-normal shadow-none will-change-transform active:scale-none [&_svg]:text-muted-foreground"
           variant="outline"
           size="sm"
           onClick={() => {
@@ -508,7 +508,7 @@ function BlockViewerFileTree() {
     <SidebarProvider className="flex min-h-full flex-col [--sidebar:var(--surface)] dark:[--sidebar-accent:var(--muted)]/50">
       <Sidebar collapsible="none" className="w-full flex-1 rounded-xl p-1 pt-0">
         <SidebarGroupLabel className="h-10 rounded-none px-4 text-sm">
-          Explorer
+          Files
         </SidebarGroupLabel>
 
         <SidebarGroup className="flex-1 rounded-[9px] border bg-background px-0">

--- a/src/components/code-block-command.tsx
+++ b/src/components/code-block-command.tsx
@@ -72,7 +72,6 @@ export function CodeBlockCommand({
                     data-language="bash"
                     className="font-mono text-sm/none text-muted-foreground"
                   >
-                    <span className="select-none">$ </span>
                     {value}
                   </code>
                 </pre>

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -12,6 +12,7 @@ import {
   ScissorsIcon,
   SeparatorHorizontalIcon,
   SquareDashed,
+  Star,
   SunDimIcon,
   TerminalIcon,
   TerminalSquareIcon,
@@ -726,9 +727,25 @@ export function ComponentIcon({ variant, ...props }: ComponentIconProps) {
       return <GalleryHorizontalEndIcon {...props} />
     }
 
-    case "github-stars":
+    case "github-stars": {
+      return <Star {...props} />
+    }
+
     case "github-contributions": {
-      return <Icons.github {...props} />
+      return (
+        // Icon designed by @ncdai
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          aria-hidden
+          {...props}
+        >
+          <path
+            fill="currentColor"
+            d="M11 5h2v2h-2zM15 17h2v2h-2zM7 17h2v2H7zM15 5h2v2h-2zM15 13h2v2h-2zM11 13h2v2h-2zM11 17h2v2h-2zM15 9h2v2h-2zM3 13h2v2H3zM3 17h2v2H3zM3 9h2v2H3zM3 5h2v2H3zM7 9h2v2H7zM19 17h2v2h-2zM19 9h2v2h-2zM7 5h2v2H7z"
+          />
+        </svg>
+      )
     }
 
     case "scroll-fade-effect": {

--- a/src/components/registry-command-animated.tsx
+++ b/src/components/registry-command-animated.tsx
@@ -80,7 +80,6 @@ export function RegistryCommandAnimated() {
                   value={key}
                   render={<span className="block sm:inline-block" />}
                 >
-                  <span className="select-none">$ </span>
                   {command} shadcn add{" "}
                   <span className="select-none sm:hidden" aria-hidden="true">
                     \

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,12 +1,16 @@
-import { GeistMono } from "geist/font/mono"
 import { GeistPixelSquare } from "geist/font/pixel"
 import { GeistSans } from "geist/font/sans"
+import { JetBrains_Mono } from "next/font/google"
 import localFont from "next/font/local"
 
 import { cn } from "@/lib/utils"
 
 const fontSans = GeistSans
-const fontMono = GeistMono
+
+const fontMono = JetBrains_Mono({
+  weight: ["400", "500"],
+  variable: "--font-mono",
+})
 
 const fontSerif = localFont({
   src: "../assets/fonts/charter_regular.woff2",
@@ -15,19 +19,17 @@ const fontSerif = localFont({
   variable: "--font-serif",
 })
 
-const fontPixel = localFont({
-  src: "../assets/fonts/DepartureMono-Regular.woff2",
-  weight: "400",
-  fallback: ["monospace"],
-  variable: "--font-pixel",
-})
+// const fontPixel = localFont({
+//   src: "../assets/fonts/DepartureMono-Regular.woff2",
+//   weight: "400",
+//   fallback: ["monospace"],
+//   variable: "--font-pixel",
+// })
 
 export const fontVariables = cn(
   fontSans.variable,
   fontMono.variable,
   fontSerif.variable,
-  fontPixel.variable,
   GeistPixelSquare.variable,
-  "[--font-sans:var(--font-geist-sans)]",
-  "[--font-mono:var(--font-geist-mono)]"
+  "[--font-sans:var(--font-geist-sans)]"
 )

--- a/src/registry/components/type-table/type-table.tsx
+++ b/src/registry/components/type-table/type-table.tsx
@@ -111,7 +111,7 @@ function Item({
       <CollapsibleTrigger className="not-prose relative flex w-full flex-row items-center rounded-lg px-3 py-2 text-start text-sm ring-border outline-none ring-inset group-data-open/type-item:rounded-b-none group-data-open/type-item:ring-1 hover:bg-accent focus-visible:ring-1 focus-visible:ring-ring/50 dark:hover:bg-[color-mix(in_oklab,var(--accent)_60%,var(--surface))] [&_svg]:size-4">
         <code
           className={cn(
-            "[--shiki-dark:#FFF] [--shiki-light:#6F42C1]",
+            "[--shiki-dark:#FFC799] [--shiki-light:#005CC5]",
             "w-1/4 min-w-fit shrink-0 pr-2 font-mono text-(--shiki-light) dark:text-(--shiki-dark)",
             deprecated && "line-through opacity-50"
           )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -115,7 +115,6 @@
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
   --font-serif: var(--font-serif);
-  --font-pixel: var(--font-pixel);
   --font-pixel-square: var(--font-geist-pixel-square);
   --font-heading: var(--font-sans);
 


### PR DESCRIPTION
- Replace GeistMono with JetBrains Mono for better code readability
- Remove custom pixel font in favor of GeistPixelSquare
- Update sponsors page heading to use heading font with larger size
- Change file explorer label from "Explorer" to "Files"
- Remove command prompt symbols from code blocks for cleaner look
- Add dedicated GitHub contributions icon and update stars icon
- Improve type table syntax highlighting colors
- Add font-normal weight to block viewer toolbar button