### PR TITLE
feat: add IconSwap component with smooth transition animations

### DIFF
--- a/src/components/code-block-command.tsx
+++ b/src/components/code-block-command.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/base/ui/tabs"
 import type { PackageManager } from "@/hooks/use-package-manager"
 import { usePackageManager } from "@/hooks/use-package-manager"
+import { IconSwap, IconSwapItem } from "@/registry/components/icon-swap"
 import type { NpmCommands } from "@/types/unist"
 
 import { CopyButton } from "./copy-button"
@@ -43,8 +44,12 @@ export function CodeBlockCommand({
         }}
       >
         <div className="px-3">
-          <TabsList className="h-10 rounded-none bg-transparent p-0 inset-ring-0 dark:bg-transparent [&_svg]:mr-2 [&_svg]:size-4 [&_svg]:text-muted-foreground">
-            {getIconForPackageManager(packageManager)}
+          <TabsList className="h-10 rounded-none bg-transparent p-0 inset-ring-0 dark:bg-transparent [&_svg]:size-4 [&_svg]:text-muted-foreground">
+            <IconSwap>
+              <IconSwapItem className="mr-2" key={packageManager}>
+                {getIconForPackageManager(packageManager)}
+              </IconSwapItem>
+            </IconSwap>
 
             {Object.entries(tabs).map(([key]) => {
               return (

--- a/src/components/registry-command-animated.tsx
+++ b/src/components/registry-command-animated.tsx
@@ -7,6 +7,7 @@ import { registryConfig } from "@/config/registry"
 import type { PackageManager } from "@/hooks/use-package-manager"
 import { usePackageManager } from "@/hooks/use-package-manager"
 import { components } from "@/registry/components/_registry"
+import { IconSwap, IconSwapItem } from "@/registry/components/icon-swap"
 import { TextFlip } from "@/registry/components/text-flip"
 
 import {
@@ -49,8 +50,12 @@ export function RegistryCommandAnimated() {
         }}
       >
         <div className="px-4 shadow-[inset_0_-1px_0_0] shadow-line">
-          <TabsList className="h-10 rounded-none bg-transparent p-0 inset-ring-0 dark:bg-transparent [&_svg]:me-2 [&_svg]:size-4 [&_svg]:text-muted-foreground">
-            {getIconForPackageManager(packageManager)}
+          <TabsList className="h-10 rounded-none bg-transparent p-0 inset-ring-0 dark:bg-transparent [&_svg]:size-4 [&_svg]:text-muted-foreground">
+            <IconSwap>
+              <IconSwapItem className="mr-2" key={packageManager}>
+                {getIconForPackageManager(packageManager)}
+              </IconSwapItem>
+            </IconSwap>
 
             {Object.entries(pmCommands).map(([key]) => {
               return (

--- a/src/registry/components/icon-swap/icon-swap.tsx
+++ b/src/registry/components/icon-swap/icon-swap.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import type { AnimatePresenceProps, HTMLMotionProps } from "motion/react"
+import { AnimatePresence, motion } from "motion/react"
+
+export function IconSwap(props: React.PropsWithChildren<AnimatePresenceProps>) {
+  return <AnimatePresence mode="popLayout" initial={false} {...props} />
+}
+
+type MotionElement = typeof motion.div | typeof motion.span
+
+export function IconSwapItem({
+  as: Component = motion.div,
+  ...props
+}: HTMLMotionProps<"div"> & {
+  as?: MotionElement
+}) {
+  return (
+    <Component
+      initial={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+      animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+      exit={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+      transition={{
+        type: "spring",
+        duration: 0.3,
+        bounce: 0,
+      }}
+      {...props}
+    />
+  )
+}

--- a/src/registry/components/icon-swap/index.ts
+++ b/src/registry/components/icon-swap/index.ts
@@ -1,0 +1,1 @@
+export * from "./icon-swap"


### PR DESCRIPTION
Add new IconSwap and IconSwapItem components that provide smooth scale, opacity, and blur transitions for icon changes. Integrate the component into code block and registry command components to animate package manager icon transitions.