### PR TITLE
refactor: simplify portfolio layout by removing redundant separators

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -52,14 +52,8 @@ export default function HomePage() {
         <Separator />
 
         <About />
-        <div className="flex h-2 w-full border-x border-line" />
-
         <Testimonials />
-        <div className="flex h-2 w-full border-x border-line" />
-
         <GitHubContributions />
-        <Separator />
-
         <TechStack />
       </div>
 

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -11,7 +11,6 @@ import {
   Crown,
   Download,
   FileText,
-  Layers,
   MoonStar,
   Quote,
   RssIcon,
@@ -117,12 +116,6 @@ const PORTFOLIO_LINKS: CommandLinkItem[] = [
     href: "/#about",
     kind: "page",
     icon: <TextInitial />,
-  },
-  {
-    title: "Stack",
-    href: "/#stack",
-    kind: "page",
-    icon: <Layers />,
   },
   {
     title: "Experience",

--- a/src/features/portfolio/components/github-contributions/index.tsx
+++ b/src/features/portfolio/components/github-contributions/index.tsx
@@ -9,12 +9,14 @@ export function GitHubContributions() {
   const contributions = getGitHubContributions()
 
   return (
-    <Panel>
+    <Panel className="before:content-none">
       <h2 className="sr-only">GitHub Contributions</h2>
 
       <Suspense fallback={<GitHubContributionFallback />}>
         <GitHubContributionGraph contributions={contributions} />
       </Suspense>
+
+      <div className="flex h-px" />
     </Panel>
   )
 }

--- a/src/features/portfolio/components/tech-stack.tsx
+++ b/src/features/portfolio/components/tech-stack.tsx
@@ -1,14 +1,12 @@
 import Image from "next/image"
 
 import { TECH_STACK } from "../data/tech-stack"
-import { Panel, PanelContent, PanelHeader, PanelTitle } from "./panel"
+import { Panel, PanelContent } from "./panel"
 
 export function TechStack() {
   return (
-    <Panel id="stack">
-      <PanelHeader>
-        <PanelTitle>Stack</PanelTitle>
-      </PanelHeader>
+    <Panel id="stack" className="before:content-none">
+      <h2 className="sr-only">Stack</h2>
 
       <PanelContent>
         <ul className="flex flex-wrap gap-2">
@@ -57,6 +55,8 @@ export function TechStack() {
           })}
         </ul>
       </PanelContent>
+
+      <div className="flex h-px" />
     </Panel>
   )
 }

--- a/src/features/portfolio/components/testimonials.tsx
+++ b/src/features/portfolio/components/testimonials.tsx
@@ -36,39 +36,42 @@ export function Testimonials() {
   return (
     <Panel
       id="testimonials"
-      className="before:content-none after:content-none [&_.rfm-initial-child-container]:items-stretch! [&_.rfm-marquee]:items-stretch!"
+      className="before:content-none [&_.rfm-initial-child-container]:items-stretch! [&_.rfm-marquee]:items-stretch!"
     >
       <h2 className="sr-only">Testimonials</h2>
 
-      <div className="grid gap-2 px-2 sm:grid-cols-2">
-        {FEATURED_TESTIMONIALS.map((item) => (
-          <a
-            key={item.url}
-            className="flex"
-            href={item.url}
-            target="_blank"
-            rel="noopener"
-          >
-            <TestimonialSpotlight
-              className="flex-1 bg-accent-muted"
-              spotlightSize="50%"
+      <div className="grid gap-2 py-2">
+        <div className="grid gap-2 px-2 sm:grid-cols-2">
+          {FEATURED_TESTIMONIALS.map((item) => (
+            <a
+              key={item.url}
+              className="flex"
+              href={item.url}
+              target="_blank"
+              rel="noopener"
             >
-              <TestimonialItem {...item} />
-            </TestimonialSpotlight>
-          </a>
-        ))}
+              <TestimonialSpotlight
+                className="flex-1 bg-accent-muted"
+                spotlightSize="50%"
+              >
+                <TestimonialItem {...item} />
+              </TestimonialSpotlight>
+            </a>
+          ))}
+        </div>
+
+        <TestimonialList data={TESTIMONIALS_1} />
+
+        <TestimonialList data={TESTIMONIALS_2} direction="right" />
       </div>
 
-      <div className="flex h-2 w-full" />
-
-      <TestimonialList data={TESTIMONIALS_1} />
-
-      <div className="flex h-2 w-full" />
-
-      <TestimonialList data={TESTIMONIALS_2} direction="right" />
-
-      <div className="absolute right-0 bottom-0 z-10 -translate-x-2 rounded-lg bg-background ring-1 ring-background">
-        <Button className="size-7" variant="outline" size="icon-sm" asChild>
+      <div className="absolute right-0 bottom-0 z-10 -translate-x-2 -translate-y-2 rounded-lg bg-background">
+        <Button
+          className="size-7 border-none shadow-sm ring-1 ring-foreground/10 dark:ring-foreground/15"
+          variant="ghost"
+          size="icon-sm"
+          asChild
+        >
           <a
             href="/testimonials"
             target="_blank"
@@ -79,6 +82,8 @@ export function Testimonials() {
           </a>
         </Button>
       </div>
+
+      <div className="flex h-px" />
     </Panel>
   )
 }


### PR DESCRIPTION
Remove manual border dividers and separators between sections, update Panel components to handle spacing internally with before:content-none and bottom spacing divs for cleaner layout