### PR TITLE
refactor: remove dialog component and reorganize components page layout

### DIFF
--- a/src/app/(app)/(pages)/components/page.tsx
+++ b/src/app/(app)/(pages)/components/page.tsx
@@ -1,25 +1,14 @@
-import { Grip, LayoutDashboard, PlusIcon } from "lucide-react"
+import { Grip, LayoutDashboard } from "lucide-react"
 import type { Metadata } from "next"
 import Link from "next/link"
 
 import { Button } from "@/components/base/ui/button"
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/base/ui/dialog"
-import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/base/ui/tooltip"
-import { ComponentIcon } from "@/components/icons"
-import { MDX } from "@/components/mdx"
+import { ComponentIcon, Icons } from "@/components/icons"
 import {
   PageHeading,
   PageHeadingTagline,
@@ -68,15 +57,23 @@ export const metadata: Metadata = {
   },
 }
 
-const addRegistryCode = `\`\`\`bash
-npx shadcn@latest registry add ${registryConfig.namespace}
-\`\`\``
+// const addRegistryCode = `\`\`\`bash
+// npx shadcn@latest registry add ${registryConfig.namespace}
+// \`\`\``
 
 export default function Page() {
   const posts = getDocsByCategory("components")
 
+  const trustedRegistryUrl = addQueryParams(
+    "https://ui.shadcn.com/docs/directory",
+    {
+      q: registryConfig.namespace,
+      ...UTM_PARAMS,
+    }
+  )
+
   return (
-    <div className="min-h-svh">
+    <div>
       <PageHeading>
         <PageHeadingTagline>Components</PageHeadingTagline>
         <PageHeadingTitle>Pixel-perfect, uniquely crafted.</PageHeadingTitle>
@@ -86,57 +83,19 @@ export default function Page() {
 
       <div className="screen-line-top screen-line-bottom">
         <RegistryCommandAnimated />
-
-        <Dialog>
-          <DialogTrigger
-            render={
-              <Button
-                className="absolute top-1.5 right-10 h-7 gap-1.5 border-none pr-2.5 pl-2"
-                variant="secondary"
-                size="sm"
-              >
-                <PlusIcon />
-                Add
-              </Button>
-            }
-          />
-
-          <DialogContent className="sm:max-w-lg">
-            <DialogHeader>
-              <DialogTitle>Add Registry</DialogTitle>
-              <DialogDescription className="text-balance">
-                Run this command to add{" "}
-                <a
-                  className="text-foreground link-underline"
-                  href={addQueryParams("https://ui.shadcn.com/docs/directory", {
-                    q: registryConfig.namespace,
-                    ...UTM_PARAMS,
-                  })}
-                  target="_blank"
-                  rel="noopener"
-                >
-                  {registryConfig.namespace}
-                </a>{" "}
-                to your project.
-              </DialogDescription>
-            </DialogHeader>
-
-            <div className="overflow-auto *:data-rehype-pretty-code-figure:my-0">
-              <MDX code={addRegistryCode} />
-            </div>
-
-            <DialogFooter>
-              <DialogClose render={<Button>Done</Button>} />
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
       </div>
 
       <Separator />
 
       <div className="screen-line-bottom h-px" />
 
-      <div className="flex items-center justify-end gap-1.5 p-1.5">
+      <div className="flex items-center gap-1.5 p-1.5 pl-4">
+        <div className="flex flex-1">
+          <span className="text-sm font-medium text-muted-foreground">
+            {posts.length} components
+          </span>
+        </div>
+
         <Tooltip>
           <TooltipTrigger
             render={
@@ -174,6 +133,47 @@ export default function Page() {
             <p>Showcase</p>
           </TooltipContent>
         </Tooltip>
+
+        {/* <Dialog>
+          <DialogTrigger
+            render={
+              <Button
+                className="h-7 gap-1.5 border-none pr-2.5 pl-2"
+                variant="secondary"
+                size="sm"
+              >
+                <PlusIcon />
+                Add
+              </Button>
+            }
+          />
+
+          <DialogContent className="sm:max-w-lg">
+            <DialogHeader>
+              <DialogTitle>Add Registry</DialogTitle>
+              <DialogDescription className="text-balance">
+                Run this command to add{" "}
+                <a
+                  className="text-foreground link-underline"
+                  href={trustedRegistryUrl}
+                  target="_blank"
+                  rel="noopener"
+                >
+                  {registryConfig.namespace}
+                </a>{" "}
+                to your project.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="overflow-auto *:data-rehype-pretty-code-figure:my-0">
+              <MDX code={addRegistryCode} />
+            </div>
+
+            <DialogFooter>
+              <DialogClose render={<Button>Done</Button>} />
+            </DialogFooter>
+          </DialogContent>
+        </Dialog> */}
       </div>
 
       <div className="screen-line-bottom h-px" />
@@ -210,7 +210,27 @@ export default function Page() {
         </div>
       </div>
 
-      <div className="h-2" />
+      <div
+        className={cn(
+          "relative before:absolute before:left-[-100vw] before:-z-1 before:h-full before:w-[200vw]",
+          "before:bg-[repeating-linear-gradient(315deg,var(--pattern-foreground)_0,var(--pattern-foreground)_1px,transparent_0,transparent_50%)] before:bg-size-[10px_10px] before:[--pattern-foreground:var(--color-line)]/56"
+        )}
+      >
+        <div className="flex justify-center p-4">
+          <a
+            className="flex h-7 items-center gap-1 rounded-full bg-primary pr-2.5 pl-2 text-sm font-medium whitespace-nowrap text-primary-foreground select-none [&>svg]:pointer-events-none [&>svg]:size-4 [&>svg]:shrink-0"
+            href={trustedRegistryUrl}
+            target="_blank"
+            rel="noopener"
+          >
+            <Icons.trustedRegistry />
+            Trusted Registry
+          </a>
+        </div>
+      </div>
+
+      <div className="screen-line-bottom h-px" />
+      <div className="h-4" />
     </div>
   )
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -620,6 +620,24 @@ export const Icons = {
       />
     </svg>
   ),
+
+  // Designed by @ncdai
+  trustedRegistry: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M6 18.5145C4.76261 17.1236 4 15.3344 4 13.0004V6.00045C4 5.73523 4.10536 5.48088 4.29289 5.29334C4.48043 5.10581 4.73478 5.00045 5 5.00045C7 5.00045 9.5 3.80045 11.24 2.28045C11.4519 2.09945 11.7214 2 12 2C12.2786 2 12.5481 2.09945 12.76 2.28045C14.51 3.81045 17 5.00045 19 5.00045C19.2652 5.00045 19.5196 5.10581 19.7071 5.29334C19.8946 5.48088 20 5.73523 20 6.00045V9" />
+      <path d="M19 17L14 22" />
+      <path d="M18 12L9 21" />
+    </svg>
+  ),
 }
 
 export function getIconForLanguageExtension(language: string) {

--- a/src/components/registry-command-animated.tsx
+++ b/src/components/registry-command-animated.tsx
@@ -115,7 +115,8 @@ export function RegistryCommandAnimated() {
       </Tabs>
 
       <CopyButton
-        className="absolute top-1.5 right-1.5 z-10 size-7 border-none"
+        className="absolute top-1.5 right-1.5 z-10 size-7 border-none text-muted-foreground"
+        variant="ghost"
         size="icon-sm"
         text={() => {
           const baseCommand = pmCommands[packageManager] || pmCommands["pnpm"]


### PR DESCRIPTION
Remove unused Dialog imports and commented out add registry dialog. Add component count display and trusted registry link section. Update layout spacing and positioning for better visual hierarchy.