### PR TITLE
feat: add dismissible functionality to doc sponsors component

### DIFF
--- a/src/features/doc/components/doc-sponsors.tsx
+++ b/src/features/doc/components/doc-sponsors.tsx
@@ -1,22 +1,49 @@
+"use client"
+
+import { useState } from "react"
 import { addQueryParams } from "@/utils/url"
+import { XIcon } from "lucide-react"
 
 import { UTM_PARAMS } from "@/config/site"
+import { trackEvent } from "@/lib/events"
+import { Button } from "@/components/base/ui/button"
 import { SPONSORS } from "@/features/sponsor/data"
 
 const GOLD_SPONSORS = SPONSORS.filter((sponsor) => sponsor.tier === "gold")
 
 export function DocSponsors() {
+  const [visible, setVisible] = useState(true)
+
+  if (!visible) {
+    return null
+  }
+
   return (
     <aside
-      className="not-prose my-[1.25em] rounded-xl bg-surface p-1 inset-ring-1 inset-ring-border/64"
+      className="not-prose my-[1.25em] rounded-xl bg-surface p-1 pt-0 inset-ring-1 inset-ring-border/64"
       aria-labelledby="doc-sponsors-heading"
     >
-      <h2
-        id="doc-sponsors-heading"
-        className="px-3 pt-2 pb-3 font-heading text-sm/none font-medium text-muted-foreground"
-      >
-        Gold Sponsors
-      </h2>
+      <div className="flex items-center justify-between pt-1 pb-0.75 pl-3">
+        <h2
+          id="doc-sponsors-heading"
+          className="font-heading text-sm/none font-medium text-muted-foreground"
+        >
+          Gold Sponsors
+        </h2>
+
+        <Button
+          aria-label="Close"
+          className="size-7 rounded-lg border-none text-muted-foreground"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => {
+            trackEvent({ name: "doc_sponsors_close" })
+            setVisible(false)
+          }}
+        >
+          <XIcon />
+        </Button>
+      </div>
 
       <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2">
         {GOLD_SPONSORS.map((item) => (

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -25,6 +25,7 @@ const eventSchema = z.object({
     "block_viewer_open_preview",
     "block_viewer_refresh_preview",
     "block_viewer_theme_change",
+    "doc_sponsors_close",
   ]),
   // declare type AllowedPropertyValues = string | number | boolean | null
   properties: z


### PR DESCRIPTION
Add close button with X icon to allow users to hide the gold sponsors section. Track dismissal events for analytics and improve UX by making the sponsors section less intrusive.