### PR TITLE
feat: add date-fns dependency to metrics-01 block

### DIFF
--- a/public/r/metrics-01.json
+++ b/public/r/metrics-01.json
@@ -4,6 +4,9 @@
   "title": "Metrics 01",
   "author": "ncdai <dai@chanhdai.com>",
   "description": "A metrics section with a line chart.",
+  "dependencies": [
+    "date-fns"
+  ],
   "registryDependencies": [
     "@bklit/line-chart",
     "https://chanhdai.com/r/style.json"

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -1097,6 +1097,9 @@
       "name": "metrics-01",
       "title": "Metrics 01",
       "description": "A metrics section with a line chart.",
+      "dependencies": [
+        "date-fns"
+      ],
       "registryDependencies": [
         "@bklit/line-chart",
         "https://chanhdai.com/r/style.json"

--- a/src/registry/blocks/_registry.ts
+++ b/src/registry/blocks/_registry.ts
@@ -190,6 +190,7 @@ export const blocks: Registry["items"] = [
     title: "Metrics 01",
     description: "A metrics section with a line chart.",
     type: "registry:block",
+    dependencies: ["date-fns"],
     registryDependencies: ["@bklit/line-chart", getRegistryItemUrl("style")],
     files: [
       {

--- a/src/registry/registry.autogenerated.json
+++ b/src/registry/registry.autogenerated.json
@@ -1097,6 +1097,9 @@
       "name": "metrics-01",
       "title": "Metrics 01",
       "description": "A metrics section with a line chart.",
+      "dependencies": [
+        "date-fns"
+      ],
       "registryDependencies": [
         "@bklit/line-chart",
         "https://chanhdai.com/r/style.json"


### PR DESCRIPTION
Add date-fns as a required dependency for the metrics-01 block across all registry files to support date formatting functionality in the line chart component.