### PR TITLE
fix: wrap DialogTitle content in span with asChild prop

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -41,7 +41,9 @@ function CommandDialog({
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
+        <DialogTitle asChild>
+          <span>{title}</span>
+        </DialogTitle>
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
 


### PR DESCRIPTION
Prevents hydration mismatch by ensuring DialogTitle renders as span instead of default heading element when used with screen readers