### PR TITLE
feat: add collapsible experience list with show more/less functionality

### DIFF
--- a/src/components/ui/tag.tsx
+++ b/src/components/ui/tag.tsx
@@ -7,7 +7,7 @@ function Tag({ className, ...props }: React.ComponentProps<"span">) {
     <span
       data-slot="tag"
       className={cn(
-        "inline-flex items-center rounded-md border bg-zinc-50 px-1.5 py-0.5 font-mono text-xs text-muted-foreground dark:bg-zinc-900 retina:border-[0.5px]",
+        "inline-flex items-center rounded-md border bg-zinc-50 px-1.5 py-0.5 font-mono text-xs text-muted-foreground dark:bg-zinc-900",
         "[&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
         className
       )}

--- a/src/features/portfolio/components/experiences/index.tsx
+++ b/src/features/portfolio/components/experiences/index.tsx
@@ -1,8 +1,22 @@
-import React from "react"
+import { ChevronDownIcon } from "lucide-react"
 
-import { EXPERIENCES } from "../../data/experiences"
-import { Panel, PanelHeader, PanelTitle } from "../panel"
+import { Button } from "@/components/base/ui/button"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/base/ui/collapsible"
+import {
+  Panel,
+  PanelHeader,
+  PanelTitle,
+} from "@/features/portfolio/components/panel"
+import { EXPERIENCES } from "@/features/portfolio/data/experiences"
+import type { Experience } from "@/features/portfolio/types/experiences"
+
 import { ExperienceItem } from "./experience-item"
+
+const MAX = 3
 
 export function Experiences() {
   return (
@@ -12,10 +26,44 @@ export function Experiences() {
       </PanelHeader>
 
       <div className="pr-2 pl-4">
-        {EXPERIENCES.map((experience) => (
-          <ExperienceItem key={experience.id} experience={experience} />
-        ))}
+        <ExperienceList experiences={EXPERIENCES.slice(0, MAX)} />
       </div>
+
+      {EXPERIENCES.length > MAX && (
+        <Collapsible className="group/collapsible">
+          <CollapsibleContent render={<div className="pr-2 pl-4" />}>
+            <ExperienceList experiences={EXPERIENCES.slice(MAX)} />
+          </CollapsibleContent>
+
+          <div className="flex h-12 items-center justify-center">
+            <CollapsibleTrigger
+              render={
+                <Button className="gap-2 border-none pr-2.5 pl-3" size="sm">
+                  <span className="hidden group-data-closed/collapsible:block">
+                    Show More
+                  </span>
+
+                  <span className="hidden group-data-open/collapsible:block">
+                    Show Less
+                  </span>
+
+                  <ChevronDownIcon className="group-data-open/collapsible:rotate-180" />
+                </Button>
+              }
+            />
+          </div>
+        </Collapsible>
+      )}
     </Panel>
+  )
+}
+
+function ExperienceList({ experiences }: { experiences: Experience[] }) {
+  return (
+    <>
+      {experiences.map((experience) => (
+        <ExperienceItem key={experience.id} experience={experience} />
+      ))}
+    </>
   )
 }


### PR DESCRIPTION
Add collapsible behavior to experiences section to initially show only 3 items with option to expand and view all experiences. Remove retina border styling from tag component for cleaner appearance.