### PR TITLE
feat: improve GitHub contributions graph and text flip component layout

### DIFF
--- a/src/features/portfolio/components/github-contributions/graph.tsx
+++ b/src/features/portfolio/components/github-contributions/graph.tsx
@@ -34,7 +34,7 @@ export function GitHubContributionGraph({
       data={data}
       blockSize={11}
       blockMargin={3}
-      blockRadius={2}
+      blockRadius={0}
       aria-label="GitHub Contributions Graph"
     >
       <ContributionGraphCalendar

--- a/src/features/portfolio/components/profile-activity-mosaic-cover/index.tsx
+++ b/src/features/portfolio/components/profile-activity-mosaic-cover/index.tsx
@@ -82,5 +82,5 @@ const getGitHubContributions = unstable_cache(
     return buildContributionGrid(contributions, cellCount)
   },
   ["github-contributions", "activity-mosaic"],
-  { revalidate: 86400 } // Cache for 1 day (86400 seconds)
+  { revalidate: 7 * 24 * 60 * 60 } // Cache for 7 days
 )

--- a/src/registry/examples/text-flip-demo.tsx
+++ b/src/registry/examples/text-flip-demo.tsx
@@ -5,6 +5,8 @@ import { motion, useInView, usePageInView } from "motion/react"
 
 import { TextFlip } from "@/registry/transformed/components/text-flip"
 
+const WORDS = ["Developer", "Designer", "Creator", "Builder"]
+
 export default function TextFlipDemo() {
   const ref = useRef<HTMLDivElement>(null)
   const isPageInView = usePageInView()
@@ -12,18 +14,26 @@ export default function TextFlipDemo() {
   const play = isPageInView && isInView
 
   return (
-    <div ref={ref} className="text-2xl font-medium text-muted-foreground">
-      <span>I am a </span>
-      <TextFlip
-        as={motion.span}
-        className="min-w-32 text-foreground"
-        play={play}
-      >
-        <span>Developer</span>
-        <span>Designer</span>
-        <span>Creator</span>
-        <span>Builder</span>
-      </TextFlip>
+    <div
+      ref={ref}
+      className="flex items-center gap-1.5 text-2xl font-medium text-muted-foreground"
+    >
+      <span>I am a</span>
+      <span className="inline-grid">
+        {/* Placeholder for the tallest word */}
+        <span className="invisible col-start-1 row-start-1" aria-hidden>
+          {WORDS.reduce((a, b) => (a.length >= b.length ? a : b))}
+        </span>
+        <TextFlip
+          as={motion.span}
+          className="col-start-1 row-start-1 text-foreground"
+          play={play}
+        >
+          {WORDS.map((word) => (
+            <span key={word}>{word}</span>
+          ))}
+        </TextFlip>
+      </span>
     </div>
   )
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -163,8 +163,16 @@
   @apply relative before:absolute before:top-0 before:left-[-100vw] before:-z-1 before:h-px before:w-[200vw] before:bg-line;
 }
 
+@utility screen-dashed-line-top {
+  @apply relative before:absolute before:top-0 before:left-[-100vw] before:-z-1 before:h-px before:w-[200vw] before:border-t before:border-dashed before:border-line;
+}
+
 @utility screen-line-bottom {
   @apply relative after:absolute after:bottom-0 after:left-[-100vw] after:-z-1 after:h-px after:w-[200vw] after:bg-line;
+}
+
+@utility screen-dashed-line-bottom {
+  @apply relative after:absolute after:bottom-0 after:left-[-100vw] after:-z-1 after:h-px after:w-[200vw] after:border-b after:border-dashed after:border-line;
 }
 
 @utility step {


### PR DESCRIPTION
- Remove border radius from GitHub contribution blocks for cleaner look
- Extend cache duration for GitHub contributions from 1 day to 7 days
- Extract words array to constant for better maintainability
- Fix text flip layout to prevent width jumping using CSS grid
- Add dashed line utilities for enhanced visual styling options