### PR TITLE
feat: add JSON-LD breadcrumb navigation to improve SEO

### DIFF
--- a/src/app/(app)/(blocks)/blocks/(list)/[category]/page.tsx
+++ b/src/app/(app)/(blocks)/blocks/(list)/[category]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next"
 import { blockCategories } from "@/config/registry"
 import { X_HANDLE } from "@/config/site"
 import { getAllBlockIds } from "@/lib/blocks"
+import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { cn } from "@/lib/utils"
 import { BlockDisplay } from "@/app/(preview)/components/block-display"
 
@@ -63,10 +64,30 @@ export default async function BlocksPage({
   params,
 }: PageProps<"/blocks/[category]">) {
   const { category } = await params
+
   const blockIds = await getAllBlockIds(["registry:block"], [category])
+
+  const categoryItem = blockCategories.find((item) => item.name === category)
 
   return (
     <>
+      <JsonLdScript
+        data={jsonLdBreadcrumbList([
+          {
+            name: "Home",
+            href: "/",
+          },
+          {
+            name: "Blocks",
+            href: "/blocks",
+          },
+          {
+            name: categoryItem?.title || category,
+            href: `/blocks/${category}`,
+          },
+        ])}
+      />
+
       {blockIds.map((blockId) => (
         <Fragment key={blockId}>
           <BlockDisplay name={blockId} />

--- a/src/app/(app)/(blocks)/blocks/(list)/page.tsx
+++ b/src/app/(app)/(blocks)/blocks/(list)/page.tsx
@@ -2,6 +2,7 @@ import { Fragment } from "react"
 import type { Metadata } from "next"
 
 import { X_HANDLE } from "@/config/site"
+import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { cn } from "@/lib/utils"
 import blocks from "@/registry/__blocks__.json"
 import { BlockDisplay } from "@/app/(preview)/components/block-display"
@@ -41,6 +42,19 @@ export const metadata: Metadata = {
 export default function BlocksPage() {
   return (
     <>
+      <JsonLdScript
+        data={jsonLdBreadcrumbList([
+          {
+            name: "Home",
+            href: "/",
+          },
+          {
+            name: "Blocks",
+            href: "/blocks",
+          },
+        ])}
+      />
+
       {blocks.map(({ name }) => (
         <Fragment key={name}>
           <BlockDisplay name={name} />

--- a/src/app/(app)/(blocks)/blocks/(view)/[category]/[name]/page.tsx
+++ b/src/app/(app)/(blocks)/blocks/(view)/[category]/[name]/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react"
 import { blockCategories } from "@/config/registry"
 import { X_HANDLE } from "@/config/site"
 import { getAllBlockStaticParams } from "@/lib/blocks"
+import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { getRegistryItem } from "@/lib/registry"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -91,6 +92,27 @@ export default async function BlockViewPage({
 
   return (
     <>
+      <JsonLdScript
+        data={jsonLdBreadcrumbList([
+          {
+            name: "Home",
+            href: "/",
+          },
+          {
+            name: "Blocks",
+            href: "/blocks",
+          },
+          {
+            name: categoryItem?.title || category,
+            href: `/blocks/${category}`,
+          },
+          {
+            name,
+            href: `/blocks/${category}/${name}`,
+          },
+        ])}
+      />
+
       <DocKeyboardShortcuts
         previous={previous ? `/blocks/${previous}` : null}
         next={next ? `/blocks/${next}` : null}

--- a/src/app/(app)/(blocks)/components/showcase/page.tsx
+++ b/src/app/(app)/(blocks)/components/showcase/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { Grip, LayoutDashboard } from "lucide-react"
 
 import { X_HANDLE } from "@/config/site"
+import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { Button } from "@/components/base/ui/button"
 import {
   Tooltip,
@@ -75,6 +76,23 @@ export const metadata: Metadata = {
 export default function ComponentsShowcasePage() {
   return (
     <>
+      <JsonLdScript
+        data={jsonLdBreadcrumbList([
+          {
+            name: "Home",
+            href: "/",
+          },
+          {
+            name: "Components",
+            href: "/components",
+          },
+          {
+            name: "Component Showcase",
+            href: "/components/showcase",
+          },
+        ])}
+      />
+
       <PageHeading>
         <PageHeadingTagline>Component Showcase</PageHeadingTagline>
         <PageHeadingTitle>Pixel-perfect, uniquely crafted.</PageHeadingTitle>

--- a/src/app/(app)/(docs)/blog/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react"
 import type { BlogPosting as PageSchema, WithContext } from "schema-dts"
 
 import { SITE_INFO, X_HANDLE } from "@/config/site"
+import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
@@ -126,11 +127,23 @@ export default async function Page({ params }: PageProps<"/blog/[slug]">) {
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(getPageJsonLd(doc)).replace(/</g, "\\u003c"),
-        }}
+      <JsonLdScript data={getPageJsonLd(doc)} />
+
+      <JsonLdScript
+        data={jsonLdBreadcrumbList([
+          {
+            name: "Home",
+            href: "/",
+          },
+          {
+            name: "Blog",
+            href: "/blog",
+          },
+          {
+            name: doc.metadata.title,
+            href: `/blog/${slug}`,
+          },
+        ])}
       />
 
       <DocKeyboardShortcuts

--- a/src/app/(app)/(docs)/components/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/components/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react"
 import type { BlogPosting as PageSchema, WithContext } from "schema-dts"
 
 import { SITE_INFO, X_HANDLE } from "@/config/site"
+import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
@@ -138,11 +139,23 @@ export default async function Page({
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(getPageJsonLd(doc)).replace(/</g, "\\u003c"),
-        }}
+      <JsonLdScript data={getPageJsonLd(doc)} />
+
+      <JsonLdScript
+        data={jsonLdBreadcrumbList([
+          {
+            name: "Home",
+            href: "/",
+          },
+          {
+            name: "Components",
+            href: "/components",
+          },
+          {
+            name: doc.metadata.title,
+            href: `/components/${slug}`,
+          },
+        ])}
       />
 
       <DocKeyboardShortcuts

--- a/src/app/(app)/(pages)/blog/page.tsx
+++ b/src/app/(app)/(pages)/blog/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react"
 import type { Metadata } from "next"
 
 import { X_HANDLE } from "@/config/site"
+import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import {
   PageHeading,
   PageHeadingTagline,
@@ -45,31 +46,46 @@ export default function Page() {
   const allPosts = getAllDocs()
 
   return (
-    <div className="min-h-svh">
-      <PageHeading>
-        <PageHeadingTagline>Blog</PageHeadingTagline>
-        <PageHeadingTitle>
-          Writing about code, design, and everything in between.
-        </PageHeadingTitle>
-      </PageHeading>
+    <>
+      <JsonLdScript
+        data={jsonLdBreadcrumbList([
+          {
+            name: "Home",
+            href: "/",
+          },
+          {
+            name: "Blog",
+            href: "/blog",
+          },
+        ])}
+      />
 
-      <div className="h-4" />
+      <div className="min-h-svh">
+        <PageHeading>
+          <PageHeadingTagline>Blog</PageHeadingTagline>
+          <PageHeadingTitle>
+            Writing about code, design, and everything in between.
+          </PageHeadingTitle>
+        </PageHeading>
 
-      <div className="screen-line-top screen-line-bottom p-2">
-        <Suspense
-          fallback={
-            <div className="flex h-9 w-full rounded-lg border border-input dark:bg-input/30" />
-          }
-        >
-          <PostSearchInput />
+        <div className="h-4" />
+
+        <div className="screen-line-top screen-line-bottom p-2">
+          <Suspense
+            fallback={
+              <div className="flex h-9 w-full rounded-lg border border-input dark:bg-input/30" />
+            }
+          >
+            <PostSearchInput />
+          </Suspense>
+        </div>
+
+        <Suspense fallback={<PostList posts={allPosts} />}>
+          <PostListWithSearch posts={allPosts} />
         </Suspense>
+
+        <div className="h-4" />
       </div>
-
-      <Suspense fallback={<PostList posts={allPosts} />}>
-        <PostListWithSearch posts={allPosts} />
-      </Suspense>
-
-      <div className="h-4" />
-    </div>
+    </>
   )
 }

--- a/src/app/(app)/(pages)/components/page.tsx
+++ b/src/app/(app)/(pages)/components/page.tsx
@@ -5,6 +5,7 @@ import { Grip, LayoutDashboard } from "lucide-react"
 
 import { registryConfig } from "@/config/registry"
 import { UTM_PARAMS, X_HANDLE } from "@/config/site"
+import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/base/ui/button"
 import {
@@ -73,68 +74,82 @@ export default function Page() {
   )
 
   return (
-    <div>
-      <PageHeading>
-        <PageHeadingTagline>Components</PageHeadingTagline>
-        <PageHeadingTitle>Pixel-perfect, uniquely crafted.</PageHeadingTitle>
-      </PageHeading>
+    <>
+      <JsonLdScript
+        data={jsonLdBreadcrumbList([
+          {
+            name: "Home",
+            href: "/",
+          },
+          {
+            name: "Components",
+            href: "/components",
+          },
+        ])}
+      />
 
-      <div className="h-4" />
+      <div>
+        <PageHeading>
+          <PageHeadingTagline>Components</PageHeadingTagline>
+          <PageHeadingTitle>Pixel-perfect, uniquely crafted.</PageHeadingTitle>
+        </PageHeading>
 
-      <div className="screen-line-top screen-line-bottom">
-        <RegistryCommandAnimated />
-      </div>
+        <div className="h-4" />
 
-      <Separator />
-
-      <div className="screen-line-bottom h-px" />
-
-      <div className="flex items-center gap-1.5 p-1.5 pl-4">
-        <div className="flex flex-1">
-          <span className="text-sm font-medium text-muted-foreground">
-            {posts.length} components
-          </span>
+        <div className="screen-line-top screen-line-bottom">
+          <RegistryCommandAnimated />
         </div>
 
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                className="size-7"
-                variant="outline"
-                size="icon-sm"
-                aria-label="List"
-              >
-                <Grip />
-              </Button>
-            }
-          />
-          <TooltipContent>
-            <p>List</p>
-          </TooltipContent>
-        </Tooltip>
+        <Separator />
 
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                className="size-7 border-none text-muted-foreground"
-                variant="ghost"
-                size="icon-sm"
-                nativeButton={false}
-                render={<Link href="/components/showcase" />}
-                aria-label="Showcase"
-              >
-                <LayoutDashboard />
-              </Button>
-            }
-          />
-          <TooltipContent>
-            <p>Showcase</p>
-          </TooltipContent>
-        </Tooltip>
+        <div className="screen-line-bottom h-px" />
 
-        {/* <Dialog>
+        <div className="flex items-center gap-1.5 p-1.5 pl-4">
+          <div className="flex flex-1">
+            <span className="text-sm font-medium text-muted-foreground">
+              {posts.length} components
+            </span>
+          </div>
+
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  className="size-7"
+                  variant="outline"
+                  size="icon-sm"
+                  aria-label="List"
+                >
+                  <Grip />
+                </Button>
+              }
+            />
+            <TooltipContent>
+              <p>List</p>
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  className="size-7 border-none text-muted-foreground"
+                  variant="ghost"
+                  size="icon-sm"
+                  nativeButton={false}
+                  render={<Link href="/components/showcase" />}
+                  aria-label="Showcase"
+                >
+                  <LayoutDashboard />
+                </Button>
+              }
+            />
+            <TooltipContent>
+              <p>Showcase</p>
+            </TooltipContent>
+          </Tooltip>
+
+          {/* <Dialog>
           <DialogTrigger
             render={
               <Button
@@ -174,66 +189,67 @@ export default function Page() {
             </DialogFooter>
           </DialogContent>
         </Dialog> */}
-      </div>
-
-      <div className="screen-line-bottom h-px" />
-
-      <div className="relative overflow-x-clip">
-        <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-1 max-sm:hidden sm:grid-cols-2 md:grid-cols-3">
-          <div className="border-r border-line" />
-          <div className="border-r border-line max-md:hidden" />
         </div>
 
-        <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
-          {posts
-            .slice()
-            .sort((a, b) =>
-              a.metadata.title.localeCompare(b.metadata.title, "en", {
-                sensitivity: "base",
-              })
-            )
-            .map((c) => (
-              <li
-                key={c.slug}
-                className={cn(
-                  "max-sm:screen-line-bottom",
-                  "sm:max-md:nth-[2n+1]:screen-line-bottom",
-                  "md:nth-[3n+1]:screen-line-bottom"
-                )}
-              >
-                <ComponentItem href={`/components/${c.slug}`}>
-                  <ComponentItemIcon>
-                    <ComponentIcon variant={c.slug} />
-                    {(c.metadata.new || c.metadata.updated) && (
-                      <ComponentItemDot
-                        aria-label={c.metadata.new ? "New" : "Updated"}
-                      />
-                    )}
-                  </ComponentItemIcon>
-                  <ComponentItemTitle as="h2">
-                    {c.metadata.title}
-                  </ComponentItemTitle>
-                </ComponentItem>
-              </li>
-            ))}
-        </ul>
-      </div>
+        <div className="screen-line-bottom h-px" />
 
-      <div className="screen-line-top flex justify-center p-4 before:-top-px">
-        <a
-          className="flex h-7 items-center gap-1 rounded-full bg-primary pr-2.5 pl-2 text-sm font-medium whitespace-nowrap text-primary-foreground select-none [&>svg]:pointer-events-none [&>svg]:size-4 [&>svg]:shrink-0"
-          href={trustedRegistryUrl}
-          target="_blank"
-          rel="noopener"
-        >
-          <Icons.trustedRegistry />
-          Trusted Registry
-        </a>
-      </div>
+        <div className="relative overflow-x-clip">
+          <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-1 max-sm:hidden sm:grid-cols-2 md:grid-cols-3">
+            <div className="border-r border-line" />
+            <div className="border-r border-line max-md:hidden" />
+          </div>
 
-      <div className="screen-line-bottom h-px" />
-      <div className="h-4" />
-    </div>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+            {posts
+              .slice()
+              .sort((a, b) =>
+                a.metadata.title.localeCompare(b.metadata.title, "en", {
+                  sensitivity: "base",
+                })
+              )
+              .map((c) => (
+                <li
+                  key={c.slug}
+                  className={cn(
+                    "max-sm:screen-line-bottom",
+                    "sm:max-md:nth-[2n+1]:screen-line-bottom",
+                    "md:nth-[3n+1]:screen-line-bottom"
+                  )}
+                >
+                  <ComponentItem href={`/components/${c.slug}`}>
+                    <ComponentItemIcon>
+                      <ComponentIcon variant={c.slug} />
+                      {(c.metadata.new || c.metadata.updated) && (
+                        <ComponentItemDot
+                          aria-label={c.metadata.new ? "New" : "Updated"}
+                        />
+                      )}
+                    </ComponentItemIcon>
+                    <ComponentItemTitle as="h2">
+                      {c.metadata.title}
+                    </ComponentItemTitle>
+                  </ComponentItem>
+                </li>
+              ))}
+          </ul>
+        </div>
+
+        <div className="screen-line-top flex justify-center p-4 before:-top-px">
+          <a
+            className="flex h-7 items-center gap-1 rounded-full bg-primary pr-2.5 pl-2 text-sm font-medium whitespace-nowrap text-primary-foreground select-none [&>svg]:pointer-events-none [&>svg]:size-4 [&>svg]:shrink-0"
+            href={trustedRegistryUrl}
+            target="_blank"
+            rel="noopener"
+          >
+            <Icons.trustedRegistry />
+            Trusted Registry
+          </a>
+        </div>
+
+        <div className="screen-line-bottom h-px" />
+        <div className="h-4" />
+      </div>
+    </>
   )
 }
 

--- a/src/app/(app)/(pages)/sponsors/page.tsx
+++ b/src/app/(app)/(pages)/sponsors/page.tsx
@@ -3,6 +3,7 @@ import { addQueryParams } from "@/utils/url"
 import { ArrowUpRightIcon } from "lucide-react"
 
 import { SPONSORSHIP_URL, UTM_PARAMS, X_HANDLE } from "@/config/site"
+import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/base/ui/button"
 import {
@@ -59,41 +60,56 @@ const SPONSORS_BY_TIER = SPONSORS.reduce(
 
 export default function Page() {
   return (
-    <div>
-      <PageHeading>
-        <PageHeadingTagline>Sponsors</PageHeadingTagline>
-        <PageHeadingTitle>Backed by the community.</PageHeadingTitle>
-        <PageHeadingDescription>
-          Grateful to the sponsors who make this open-source work possible.
-        </PageHeadingDescription>
-      </PageHeading>
+    <>
+      <JsonLdScript
+        data={jsonLdBreadcrumbList([
+          {
+            name: "Home",
+            href: "/",
+          },
+          {
+            name: "Sponsors",
+            href: "/sponsors",
+          },
+        ])}
+      />
 
-      <div className="h-4" />
+      <div>
+        <PageHeading>
+          <PageHeadingTagline>Sponsors</PageHeadingTagline>
+          <PageHeadingTitle>Backed by the community.</PageHeadingTitle>
+          <PageHeadingDescription>
+            Grateful to the sponsors who make this open-source work possible.
+          </PageHeadingDescription>
+        </PageHeading>
 
-      <div className="screen-line-bottom h-px" />
+        <div className="h-4" />
 
-      {SPONSOR_TIERS.map((tier) => (
-        <SponsorsGroup
-          key={tier.name}
-          title={tier.title}
-          sponsors={SPONSORS_BY_TIER[tier.name] ?? []}
-        />
-      ))}
+        <div className="screen-line-bottom h-px" />
 
-      <div className="flex justify-center py-2">
-        <Button
-          className="gap-2 border-none pr-2.5 pl-3"
-          size="sm"
-          nativeButton={false}
-          render={<a href={SPONSORSHIP_URL} target="_blank" rel="noopener" />}
-        >
-          Sponsor My Work
-          <ArrowUpRightIcon />
-        </Button>
+        {SPONSOR_TIERS.map((tier) => (
+          <SponsorsGroup
+            key={tier.name}
+            title={tier.title}
+            sponsors={SPONSORS_BY_TIER[tier.name] ?? []}
+          />
+        ))}
+
+        <div className="flex justify-center py-2">
+          <Button
+            className="gap-2 border-none pr-2.5 pl-3"
+            size="sm"
+            nativeButton={false}
+            render={<a href={SPONSORSHIP_URL} target="_blank" rel="noopener" />}
+          >
+            Sponsor My Work
+            <ArrowUpRightIcon />
+          </Button>
+        </div>
+
+        <div className="screen-line-top h-4" />
       </div>
-
-      <div className="screen-line-top h-4" />
-    </div>
+    </>
   )
 }
 

--- a/src/app/(app)/(pages)/testimonials/page.tsx
+++ b/src/app/(app)/(pages)/testimonials/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 
 import { X_HANDLE } from "@/config/site"
+import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { cn } from "@/lib/utils"
 import {
   PageHeading,
@@ -60,67 +61,82 @@ const TESTIMONIALS = [...TESTIMONIALS_1, ...TESTIMONIALS_2].sort(
 
 export default function TestimonialsPage() {
   return (
-    <div className="min-h-svh">
-      <PageHeading>
-        <PageHeadingTagline>Testimonials</PageHeadingTagline>
-        <PageHeadingTitle>
-          Trusted by top builders on <span aria-label="X">𝕏</span>
-        </PageHeadingTitle>
-      </PageHeading>
+    <>
+      <JsonLdScript
+        data={jsonLdBreadcrumbList([
+          {
+            name: "Home",
+            href: "/",
+          },
+          {
+            name: "Testimonials",
+            href: "/testimonials",
+          },
+        ])}
+      />
 
-      <div className="relative pt-4">
-        <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-1 gap-4 max-sm:hidden sm:grid-cols-2">
-          <div className="border-r border-line" />
-          <div className="border-l border-line" />
+      <div className="min-h-svh">
+        <PageHeading>
+          <PageHeadingTagline>Testimonials</PageHeadingTagline>
+          <PageHeadingTitle>
+            Trusted by top builders on <span aria-label="X">𝕏</span>
+          </PageHeadingTitle>
+        </PageHeading>
+
+        <div className="relative pt-4">
+          <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-1 gap-4 max-sm:hidden sm:grid-cols-2">
+            <div className="border-r border-line" />
+            <div className="border-l border-line" />
+          </div>
+
+          <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {TESTIMONIALS.map((item) => (
+              <li
+                key={item.url}
+                className={cn(
+                  "max-sm:screen-line-top max-sm:screen-line-bottom",
+                  "sm:nth-[2n+1]:screen-line-top sm:nth-[2n+1]:screen-line-bottom"
+                )}
+              >
+                <Testimonial className="relative transition-[background-color] ease-out hover:bg-accent-muted">
+                  <TestimonialQuote className="font-serif text-base/snug">
+                    <p>
+                      <Twemoji>{item.quote}</Twemoji>
+                    </p>
+                  </TestimonialQuote>
+
+                  <TestimonialAuthor>
+                    <TestimonialAvatar>
+                      <TestimonialAvatarImg
+                        src={item.authorAvatar}
+                        alt={item.authorName}
+                      />
+                      <TestimonialAvatarRing />
+                    </TestimonialAvatar>
+
+                    <TestimonialAuthorName>
+                      <a href={item.url} target="_blank" rel="noopener">
+                        <span className="absolute inset-0" aria-hidden />
+                        {item.authorName}
+                      </a>
+                      {item.isVerified && (
+                        <TestimonialVerifiedBadge className="text-info">
+                          <VerifiedIcon />
+                        </TestimonialVerifiedBadge>
+                      )}
+                    </TestimonialAuthorName>
+                    <TestimonialAuthorTagline>
+                      {item.authorTagline}
+                    </TestimonialAuthorTagline>
+                  </TestimonialAuthor>
+                </Testimonial>
+              </li>
+            ))}
+          </ul>
         </div>
 
-        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          {TESTIMONIALS.map((item) => (
-            <li
-              key={item.url}
-              className={cn(
-                "max-sm:screen-line-top max-sm:screen-line-bottom",
-                "sm:nth-[2n+1]:screen-line-top sm:nth-[2n+1]:screen-line-bottom"
-              )}
-            >
-              <Testimonial className="relative transition-[background-color] ease-out hover:bg-accent-muted">
-                <TestimonialQuote className="font-serif text-base/snug">
-                  <p>
-                    <Twemoji>{item.quote}</Twemoji>
-                  </p>
-                </TestimonialQuote>
-
-                <TestimonialAuthor>
-                  <TestimonialAvatar>
-                    <TestimonialAvatarImg
-                      src={item.authorAvatar}
-                      alt={item.authorName}
-                    />
-                    <TestimonialAvatarRing />
-                  </TestimonialAvatar>
-
-                  <TestimonialAuthorName>
-                    <a href={item.url} target="_blank" rel="noopener">
-                      <span className="absolute inset-0" aria-hidden />
-                      {item.authorName}
-                    </a>
-                    {item.isVerified && (
-                      <TestimonialVerifiedBadge className="text-info">
-                        <VerifiedIcon />
-                      </TestimonialVerifiedBadge>
-                    )}
-                  </TestimonialAuthorName>
-                  <TestimonialAuthorTagline>
-                    {item.authorTagline}
-                  </TestimonialAuthorTagline>
-                </TestimonialAuthor>
-              </Testimonial>
-            </li>
-          ))}
-        </ul>
+        <div className="h-4" />
       </div>
-
-      <div className="h-4" />
-    </div>
+    </>
   )
 }

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next"
 import dynamic from "next/dynamic"
 import type { ProfilePage as PageSchema, WithContext } from "schema-dts"
 
+import { JsonLdScript } from "@/lib/json-ld"
 import { cn } from "@/lib/utils"
 import { About } from "@/features/portfolio/components/about"
 import { Awards } from "@/features/portfolio/components/awards"
@@ -37,12 +38,7 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(getPageJsonLd()).replace(/</g, "\\u003c"),
-        }}
-      />
+      <JsonLdScript data={getPageJsonLd()} />
 
       <div className="[--cover-height:162px] [--separator-height:--spacing(8)] **:data-[slot=panel]:scroll-mt-[calc(var(--header-height)+var(--separator-height))]">
         <div className="mx-auto md:max-w-3xl">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import type { WebSite, WithContext } from "schema-dts"
 
 import { META_THEME_COLORS, SITE_INFO, X_HANDLE } from "@/config/site"
 import { fontVariables } from "@/lib/fonts"
+import { JsonLdScript } from "@/lib/json-ld"
 import { Providers } from "@/components/providers"
 import { USER } from "@/features/portfolio/data/user"
 
@@ -136,12 +137,7 @@ export default function RootLayout({
             `,
           }}
         />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(getWebSiteJsonLd()).replace(/</g, "\\u003c"),
-          }}
-        />
+        <JsonLdScript data={getWebSiteJsonLd()} />
       </head>
 
       <body className="[--header-height:--spacing(14)]">

--- a/src/lib/json-ld.tsx
+++ b/src/lib/json-ld.tsx
@@ -1,0 +1,34 @@
+import type { BreadcrumbList, WithContext } from "schema-dts"
+
+import { absoluteUrl } from "@/lib/utils"
+
+export type BreadcrumbItem = {
+  name: string
+  href: string
+}
+
+export function jsonLdBreadcrumbList(
+  items: BreadcrumbItem[]
+): WithContext<BreadcrumbList> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      item: absoluteUrl(item.href),
+    })),
+  }
+}
+
+export function JsonLdScript({ data }: { data: unknown }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  )
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,3 +5,7 @@ import { twMerge } from "tailwind-merge"
 export const cn = (...inputs: ClassValue[]) => {
   return twMerge(clsx(inputs))
 }
+
+export function absoluteUrl(path: string) {
+  return `${process.env.NEXT_PUBLIC_APP_URL}${path}`
+}


### PR DESCRIPTION
Add structured data breadcrumbs to all major pages including blog, components, blocks, sponsors, and testimonials to help search engines understand site hierarchy and improve search result appearance.

refactor: extract JsonLdScript component to centralize JSON-LD rendering

Create reusable JsonLdScript component and breadcrumb utility functions to reduce code duplication and provide consistent structured data implementation across the application.