### PR TITLE
feat: add testimonial and sponsors to documentation pages

### DIFF
--- a/src/features/doc/content/mobius-loop-icon.mdx
+++ b/src/features/doc/content/mobius-loop-icon.mdx
@@ -13,6 +13,15 @@ updatedAt: 2026-05-30
   openInV0Url="https://chanhdai.com/r/mobius-loop-icon.json"
 />
 
+<Testimonial
+  authorAvatar="https://unavatar.io/x/orcdev"
+  authorName="OrcDev"
+  authorTagline="Creator of 8bitcn.com"
+  url="https://x.com/orcdev/status/2061155001444012321"
+  quote="looks really nice!"
+  date="2026-06-01"
+/>
+
 ## Installation
 
 <CodeTabs>
@@ -65,3 +74,5 @@ import { MobiusLoopIcon } from "@/components/mobius-loop-icon"
 ## References
 
 - Inspired by Fluid Functionalism’s [ThinkingIndicator](https://www.fluidfunctionalism.com/docs/thinking-indicator) component.
+
+<DocSponsors />

--- a/src/features/doc/content/spinning-circular-text.mdx
+++ b/src/features/doc/content/spinning-circular-text.mdx
@@ -89,3 +89,5 @@ import { SpinningCircularText } from "@/components/spinning-circular-text"
 ## References
 
 - [Original ring text effect demo and source code](https://x.com/jh3yy/status/1618297458752368640) by [@jh3yy](https://x.com/jh3yy)
+
+<DocSponsors />


### PR DESCRIPTION
Add OrcDev testimonial to mobius-loop-icon documentation and include DocSponsors component on both mobius-loop-icon and spinning-circular-text pages to display sponsor information