### PR TITLE
docs: separate Credits and References sections in component docs

### DIFF
--- a/.agents/skills/ncdai-writing-component-docs/SKILL.md
+++ b/.agents/skills/ncdai-writing-component-docs/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ncdai-writing-component-docs
-description: Write and review component documentation (MDX) and registry descriptions. Covers doc structure, description writing, Features, Composition, and References sections. Use when creating new component docs, updating descriptions, adding Features sections, adding Composition sections, adding References sections, or reviewing component documentation quality.
+description: Write and review component documentation (MDX) and registry descriptions. Covers doc structure, description writing, Features, Composition, Credits, and References sections. Use when creating new component docs, updating descriptions, adding Features sections, adding Composition sections, adding Credits sections, adding References sections, or reviewing component documentation quality.
 ---
 
 # Writing Component Documentation
 
-Guide for writing concise, consistent component documentation for this project's registry. Covers MDX doc structure, description writing, Features sections, Composition sections, and References sections.
+Guide for writing concise, consistent component documentation for this project's registry. Covers MDX doc structure, description writing, Features sections, Composition sections, Credits sections, and References sections.
 
 ## Key Files
 
@@ -41,7 +41,9 @@ updatedAt: YYYY-MM-DD
 
 ## Examples            (optional)
 
-## References          (optional)
+## Credits             (optional -- for inspiration/original sources)
+
+## References          (optional -- for technical reading and implementation details)
 ```
 
 ## Writing Descriptions
@@ -179,23 +181,32 @@ Testimonial
 \```
 ````
 
-## Writing References Sections
+## Credits vs References
+
+Use this quick intent check before placing a link:
+
+- Put a link in `## Credits` when it answers: "Who inspired this component?" or "What original source/product is this derived from?"
+- Put a link in `## References` when it answers: "How does this work?" or "Where can I learn implementation details/API?"
+- If one link can fit both, prefer `## Credits` and add short context. Duplicate only when both contexts are essential.
+- Skip generic links that do not help readers build, understand, or trace origin.
+
+## Writing Credits Sections
 
 ### When to Include
 
-Add `## References` when the component is inspired by, derived from, or relies on external sources that the reader would benefit from visiting. Examples: original demo or tweet that inspired the component, design course or article, underlying library docs, web platform APIs the component depends on, related shadcn/ui components.
+Add `## Credits` when the component is inspired by, derived from, or adapted from an original source the reader should be able to trace. Examples: original demo/tweet, source product interaction, canonical inspiration.
 
 ### When to Skip
 
-Skip `## References` when the component is fully self-contained and was not derived from any external source worth crediting. Do not pad with generic links (e.g., do not link to React docs or generic Tailwind docs).
+Skip `## Credits` when there is no meaningful inspiration or origin worth acknowledging.
 
 ### Rules
 
-1. Use exactly `## References` as the heading (not "Credits", not "Resources", not "See Also").
-2. Place it as the LAST section in the doc.
+1. Use exactly `## Credits` as the heading (not "Attribution", not "Thanks", not "Resources").
+2. Place it near the end, before `## References`.
 3. Bullet list of markdown links, one item per line.
 4. Keep the list short (typically 1-5 items). Every link must add value.
-5. Always credit the original creator when the component is inspired by someone else's work.
+5. Credit the original creator whenever possible.
 6. No emoji.
 
 ### Item Formats
@@ -204,32 +215,24 @@ Pick the format that matches the kind of link:
 
 | Format                                              | Use For                                                 |
 | --------------------------------------------------- | ------------------------------------------------------- |
-| `- [Title](url)`                                    | Plain reference (docs, related component, web API).     |
 | `- [Title](url) by [Author](url-or-handle)`         | Original work credit (designer, engineer, demo author). |
-| `- [Title](url) — short context`                    | When the title alone does not convey what it is.        |
+| `- [Title](url) — short context`                    | Original source/product needs additional context.       |
 | `- [Title](url) by [@handle](https://x.com/handle)` | Crediting via social handle.                            |
 
 ### Good Examples
 
 ```markdown
-## References
+## Credits
 
 - [Original glow effect demo by @jh3yy](https://x.com/jh3yy/status/1992003440579662211)
-- [DialKit](https://joshpuckett.me/dialkit)
+- [Slider in DialKit](https://joshpuckett.me/dialkit) by [Josh Puckett](https://joshpuckett.me)
 ```
 
 ```markdown
-## References
+## Credits
 
 - [theme-toggle.rdsx.dev](https://theme-toggle.rdsx.dev) by [@rds_agi](https://x.com/rds_agi)
-- [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API)
-```
-
-```markdown
-## References
-
-- [Slider in DialKit](https://joshpuckett.me/dialkit) by [Josh Puckett](https://joshpuckett.me)
-- [Creating a Slider Component](https://www.interfacecraft.dev) — Interface Craft course by Josh Puckett
+- [iPhone "Slide to Unlock"](<https://en.wikipedia.org/wiki/IPhone_(1st_generation)>) — original interaction pattern
 ```
 
 ### Bad Examples
@@ -237,21 +240,83 @@ Pick the format that matches the kind of link:
 ```markdown
 ## Credits
 
-Thanks to everyone who inspired this component! ❤️
-
-- React: https://react.dev
-- Tailwind CSS: https://tailwindcss.com
+- [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API)
 ```
 
-Issues: wrong heading name, narrative intro, emoji, raw URLs instead of markdown links, generic links that add no value (every React component depends on React).
+Issue: this is technical implementation reading, so it belongs in `## References`, not `## Credits`.
+
+```markdown
+## Credits
+
+Thanks to everyone who inspired this component! ❤️
+
+- [React](https://react.dev)
+```
+
+Issues: narrative intro is unnecessary, emoji is not allowed, and generic framework links are usually filler.
+
+## Writing References Sections
+
+### When to Include
+
+Add `## References` for technical reading that helps readers implement, understand, or extend the component. Examples: library APIs, web platform docs, implementation articles, related primitives used by the component.
+
+### When to Skip
+
+Skip `## References` when there are no high-value technical links beyond obvious generic docs.
+
+### Rules
+
+1. Use exactly `## References` as the heading (not "Resources", not "See Also").
+2. Place it as the LAST section in the doc.
+3. Bullet list of markdown links, one item per line.
+4. Keep the list short (typically 1-5 items). Every link must add value.
+5. Focus on technical/implementation value, not attribution.
+6. No emoji.
+
+### Item Formats
+
+Pick the format that matches the kind of link:
+
+| Format                           | Use For                                                |
+| -------------------------------- | ------------------------------------------------------ |
+| `- [Title](url)`                 | Library docs, related component docs, web APIs.        |
+| `- [Title](url) — short context` | Clarify why this reference matters for this component. |
+
+### Good Examples
 
 ```markdown
 ## References
 
-- https://x.com/jh3yy/status/1992003440579662211
+- [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API)
+- [Motion Layout Animations](https://motion.dev/docs/react-layout-animations) — layout transition behavior
 ```
 
-Issue: raw URL with no title or author credit. Reader cannot tell what they are clicking.
+```markdown
+## References
+
+- [Radix Select](https://www.radix-ui.com/primitives/docs/components/select)
+- [shadcn/ui Select](https://ui.shadcn.com/docs/components/select)
+```
+
+### Bad Examples
+
+```markdown
+## References
+
+- [Original glow effect demo by @jh3yy](https://x.com/jh3yy/status/1992003440579662211)
+```
+
+Issue: this is attribution/inspiration, so it belongs in `## Credits`.
+
+```markdown
+## References
+
+- [React](https://react.dev)
+- [Tailwind CSS](https://tailwindcss.com)
+```
+
+Issue: generic links with low signal; add only references with specific relevance.
 
 ## Registry Item Format
 
@@ -278,6 +343,8 @@ When creating or updating a component doc:
 4. If adding Features, write 2-4 bullet points following the rules.
 5. Decide whether `## Composition` is needed (compound/composable components).
 6. If adding Composition, draw the tree matching the Usage JSX structure.
-7. Decide whether `## References` is needed (external sources worth crediting).
-8. If adding References, credit original authors and use the correct item format.
-9. Verify section order: Preview -> Features -> Installation -> Usage -> Composition -> API Reference -> Examples -> References.
+7. Decide whether `## Credits` is needed (inspiration/original sources worth acknowledging).
+8. If adding Credits, attribute the original authors/sources and use the correct item format.
+9. Decide whether `## References` is needed (technical links that help implementation and deeper learning).
+10. If adding References, keep links technical, specific, and high-value.
+11. Verify section order: Preview -> Features -> Installation -> Usage -> Composition -> API Reference -> Examples -> Credits -> References.

--- a/src/features/doc/content/apple-hello-effect.mdx
+++ b/src/features/doc/content/apple-hello-effect.mdx
@@ -127,9 +127,12 @@ import { AppleHelloEffectVietnamese } from "@/components/apple-hello-effect-viet
   name="AppleHelloEffectProps"
 />
 
-## References
+## Credits
 
 - [Official Apple Hello Lettering, extracted from macOS Sonoma in SVG Form](https://www.figma.com/community/file/1414773009964314315/official-apple-hello-lettering)
+
+## References
+
 - [SVG pathLength](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pathLength)
 - [React Motion component](https://motion.dev/docs/react-motion-component)
 

--- a/src/features/doc/content/chevrons-up-down-icon.mdx
+++ b/src/features/doc/content/chevrons-up-down-icon.mdx
@@ -78,9 +78,9 @@ chevronsUpDownIconRef.current?.startAnimation() // morph to chevrons-down-up
 chevronsUpDownIconRef.current?.stopAnimation() // morph back to chevrons-up-down
 ```
 
-## References
+## Credits
 
-- [Chevrons Up Down](https://lucide.dev/icons/chevrons-up-down) by [Lucide](https://lucide.dev) — source icon for the resting state
-- [Chevrons Down Up](https://lucide.dev/icons/chevrons-down-up) by [Lucide](https://lucide.dev) — source icon for the animated state
+- [Chevrons Up Down](https://lucide.dev/icons/chevrons-up-down) by [Lucide](https://lucide.dev) — source icon for the resting state.
+- [Chevrons Down Up](https://lucide.dev/icons/chevrons-down-up) by [Lucide](https://lucide.dev) — source icon for the animated state.
 
 <DocSponsors />

--- a/src/features/doc/content/dot-grid-spotlight.mdx
+++ b/src/features/doc/content/dot-grid-spotlight.mdx
@@ -67,6 +67,6 @@ import { DotGridSpotlight } from "@/components/dot-grid-spotlight"
   name="DotGridSpotlightProps"
 />
 
-## References
+## Credits
 
-- Inspired by the image-generating effect of [ChatGPT](https://chatgpt.com)
+- [ChatGPT](https://chatgpt.com) — inspiration from its image-generating spotlight effect.

--- a/src/features/doc/content/elastic-slider.mdx
+++ b/src/features/doc/content/elastic-slider.mdx
@@ -169,9 +169,12 @@ When `prefers-reduced-motion` is on, rubber-band stretch and spring-based fill m
 
 </div>
 
-## References
+## Credits
 
 - [Slider in DialKit](https://joshpuckett.me/dialkit) by [Josh Puckett](https://joshpuckett.me)
+
+## References
+
 - [Creating a Slider Component](https://www.interfacecraft.dev) — Interface Craft course by Josh Puckett
 
 <DocSponsors />

--- a/src/features/doc/content/fluid-gradient-text.mdx
+++ b/src/features/doc/content/fluid-gradient-text.mdx
@@ -78,6 +78,6 @@ import { FluidGradientText } from "@/components/fluid-gradient-text"
   name="FluidGradientTextProps"
 />
 
-## References
+## Credits
 
 - [Vercel Design](https://vercel.com/design) — inspiration for this text gradient interaction.

--- a/src/features/doc/content/github-contributions.mdx
+++ b/src/features/doc/content/github-contributions.mdx
@@ -102,9 +102,12 @@ npx shadcn@latest add @ncdai/github-contributions
   name="github-contributions-halloween-theme"
 />
 
+## Credits
+
+- [Contribution Graph](https://www.kibo-ui.com/components/contribution-graph) by [Kibo UI](https://www.kibo-ui.com)
+
 ## References
 
-- [Contribution Graph](https://www.kibo-ui.com/components/contribution-graph) from Kibo UI
-- [GitHub Contributions API](https://github-contributions-api.jogruber.de) by Jonathan Gruber
+- [GitHub Contributions API](https://github.com/grubersjoe/github-contributions-api) by [Jonathan Gruber](https://jogruber.de)
 
 <DocSponsors />

--- a/src/features/doc/content/glow-card-grid.mdx
+++ b/src/features/doc/content/glow-card-grid.mdx
@@ -163,9 +163,12 @@ const params = useDialKit("GlowCard", {
 
 </Steps>
 
-## References
+## Credits
 
 - [Original glow effect demo by @jh3yy](https://x.com/jh3yy/status/1992003440579662211)
+
+## References
+
 - [DialKit](https://joshpuckett.me/dialkit)
 
 <DocSponsors />

--- a/src/features/doc/content/middle-truncation.mdx
+++ b/src/features/doc/content/middle-truncation.mdx
@@ -118,7 +118,7 @@ Split text evenly in the middle when no constraints are provided.
 </MiddleTruncation>
 ```
 
-## References
+## Credits
 
 - [Middle Truncation by @pqoqubbw](https://x.com/pqoqubbw/status/2039034994581000700)
 

--- a/src/features/doc/content/mobius-loop-icon.mdx
+++ b/src/features/doc/content/mobius-loop-icon.mdx
@@ -71,8 +71,8 @@ import { MobiusLoopIcon } from "@/components/mobius-loop-icon"
 <MobiusLoopIcon />
 ```
 
-## References
+## Credits
 
-- Inspired by Fluid Functionalism’s [ThinkingIndicator](https://www.fluidfunctionalism.com/docs/thinking-indicator) component.
+- [ThinkingIndicator](https://www.fluidfunctionalism.com/docs/thinking-indicator) by [Fluid Functionalism](https://www.fluidfunctionalism.com) — inspiration for the interaction.
 
 <DocSponsors />

--- a/src/features/doc/content/spinning-circular-text.mdx
+++ b/src/features/doc/content/spinning-circular-text.mdx
@@ -123,7 +123,7 @@ so you only need to render the visible content:
   name="SpinningCircularTextProps"
 />
 
-## References
+## Credits
 
 - [Original ring text effect demo and source code](https://x.com/jh3yy/status/1618297458752368640) by [@jh3yy](https://x.com/jh3yy)
 

--- a/src/features/doc/content/theme-toggle-effect.mdx
+++ b/src/features/doc/content/theme-toggle-effect.mdx
@@ -368,9 +368,12 @@ function toggleTheme(theme: string) {
 }
 ```
 
-## References
+## Credits
 
 - [theme-toggle.rdsx.dev](https://theme-toggle.rdsx.dev) by [@rds_agi](https://x.com/rds_agi)
+
+## References
+
 - [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API)
 
 <DocSponsors />

--- a/src/features/doc/content/toc-minimap.mdx
+++ b/src/features/doc/content/toc-minimap.mdx
@@ -95,10 +95,13 @@ import { TOCMinimap } from "@/components/toc-minimap"
   name="TOCItemType"
 />
 
+## Credits
+
+- [Notion](https://www.notion.com) — inspiration for compact document navigation.
+- [Vercel Knowledge Base](https://vercel.com/kb) — inspiration for minimal documentation navigation.
+
 ## References
 
-- [Notion](https://www.notion.com) — inspired by its compact document navigation.
-- [Vercel Knowledge Base](https://vercel.com/kb) — inspired by its minimal documentation navigation.
-- [soundcn](https://www.soundcn.xyz) — for the u-mini-map-open sound effect.
+- [soundcn](https://www.soundcn.xyz) — source for the u-mini-map-open sound effect.
 
 <DocSponsors />

--- a/src/features/doc/content/twemoji.mdx
+++ b/src/features/doc/content/twemoji.mdx
@@ -111,9 +111,12 @@ import { Twemoji } from "@/components/twemoji"
 </Twemoji>
 ```
 
-## References
+## Credits
 
 - [Twemoji by Twitter](https://github.com/twitter/twemoji)
+
+## References
+
 - [Twemoji Parser](https://github.com/twitter/twemoji-parser)
 
 <DocSponsors />


### PR DESCRIPTION
Add Credits section for attribution/inspiration sources and keep References for technical implementation details. Update skill guide to clarify when to use each section and provide formatting examples.