### PR TITLE
docs: update Credits section format to use author-centric display wit…

### DIFF
--- a/.agents/skills/ncdai-writing-component-docs/SKILL.md
+++ b/.agents/skills/ncdai-writing-component-docs/SKILL.md
@@ -187,7 +187,7 @@ Use this quick intent check before placing a link:
 
 - Put a link in `## Credits` when it answers: "Who inspired this component?" or "What original source/product is this derived from?"
 - Put a link in `## References` when it answers: "How does this work?" or "Where can I learn implementation details/API?"
-- If one link can fit both, prefer `## Credits` and add short context. Duplicate only when both contexts are essential.
+- If one link can fit both, prefer `## Credits`. Keep `Credits` minimal and place explanatory context in `## References` only when needed.
 - Skip generic links that do not help readers build, understand, or trace origin.
 
 ## Writing Credits Sections
@@ -208,31 +208,31 @@ Skip `## Credits` when there is no meaningful inspiration or origin worth acknow
 4. Keep the list short (typically 1-5 items). Every link must add value.
 5. Credit the original creator whenever possible.
 6. No emoji.
+7. Each item must display only the author name/handle, but the URL must point to the exact original source.
 
 ### Item Formats
 
-Pick the format that matches the kind of link:
+Use author-centric display text with source URLs:
 
-| Format                                              | Use For                                                 |
-| --------------------------------------------------- | ------------------------------------------------------- |
-| `- [Title](url) by [Author](url-or-handle)`         | Original work credit (designer, engineer, demo author). |
-| `- [Title](url) — short context`                    | Original source/product needs additional context.       |
-| `- [Title](url) by [@handle](https://x.com/handle)` | Crediting via social handle.                            |
+| Format                        | Use For                                          |
+| ----------------------------- | ------------------------------------------------ |
+| `- [@handle](source-url)`     | Display handle, open the exact source link.      |
+| `- [Author Name](source-url)` | Display author name, open the exact source link. |
 
 ### Good Examples
 
 ```markdown
 ## Credits
 
-- [Original glow effect demo by @jh3yy](https://x.com/jh3yy/status/1992003440579662211)
-- [Slider in DialKit](https://joshpuckett.me/dialkit) by [Josh Puckett](https://joshpuckett.me)
+- [@jh3yy](https://x.com/jh3yy)
+- [Josh Puckett](https://joshpuckett.me/dialkit)
 ```
 
 ```markdown
 ## Credits
 
-- [theme-toggle.rdsx.dev](https://theme-toggle.rdsx.dev) by [@rds_agi](https://x.com/rds_agi)
-- [iPhone "Slide to Unlock"](<https://en.wikipedia.org/wiki/IPhone_(1st_generation)>) — original interaction pattern
+- [@rds_agi](https://x.com/rds_agi)
+- [Apple](https://www.figma.com/community/file/1414773009964314315/official-apple-hello-lettering)
 ```
 
 ### Bad Examples
@@ -243,17 +243,17 @@ Pick the format that matches the kind of link:
 - [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API)
 ```
 
-Issue: this is technical implementation reading, so it belongs in `## References`, not `## Credits`.
+Issue: this is technical implementation reading, so it belongs in `## References`, not `## Credits`. It is also not an author label.
 
 ```markdown
 ## Credits
 
 Thanks to everyone who inspired this component! ❤️
 
-- [React](https://react.dev)
+- [Original glow effect demo by @jh3yy](https://x.com/jh3yy/status/1992003440579662211)
 ```
 
-Issues: narrative intro is unnecessary, emoji is not allowed, and generic framework links are usually filler.
+Issues: narrative intro is unnecessary, emoji is not allowed, and item should be author-only text with the source URL (for example `[@jh3yy](https://x.com/jh3yy/status/1618297458752368640)`).
 
 ## Writing References Sections
 
@@ -344,7 +344,7 @@ When creating or updating a component doc:
 5. Decide whether `## Composition` is needed (compound/composable components).
 6. If adding Composition, draw the tree matching the Usage JSX structure.
 7. Decide whether `## Credits` is needed (inspiration/original sources worth acknowledging).
-8. If adding Credits, attribute the original authors/sources and use the correct item format.
+8. If adding Credits, use only author name/handle as link text, and always point to the exact source URL.
 9. Decide whether `## References` is needed (technical links that help implementation and deeper learning).
 10. If adding References, keep links technical, specific, and high-value.
 11. Verify section order: Preview -> Features -> Installation -> Usage -> Composition -> API Reference -> Examples -> Credits -> References.

--- a/src/features/doc/content/apple-hello-effect.mdx
+++ b/src/features/doc/content/apple-hello-effect.mdx
@@ -129,7 +129,7 @@ import { AppleHelloEffectVietnamese } from "@/components/apple-hello-effect-viet
 
 ## Credits
 
-- [Official Apple Hello Lettering, extracted from macOS Sonoma in SVG Form](https://www.figma.com/community/file/1414773009964314315/official-apple-hello-lettering)
+- [JaceThings](https://github.com/JaceThings/SF-Hello)
 
 ## References
 

--- a/src/features/doc/content/chevrons-up-down-icon.mdx
+++ b/src/features/doc/content/chevrons-up-down-icon.mdx
@@ -80,7 +80,6 @@ chevronsUpDownIconRef.current?.stopAnimation() // morph back to chevrons-up-down
 
 ## Credits
 
-- [Chevrons Up Down](https://lucide.dev/icons/chevrons-up-down) by [Lucide](https://lucide.dev) — source icon for the resting state.
-- [Chevrons Down Up](https://lucide.dev/icons/chevrons-down-up) by [Lucide](https://lucide.dev) — source icon for the animated state.
+- [Lucide](https://lucide.dev/icons/chevrons-up-down)
 
 <DocSponsors />

--- a/src/features/doc/content/copy-button.mdx
+++ b/src/features/doc/content/copy-button.mdx
@@ -102,6 +102,6 @@ See [shadcn/ui](https://ui.shadcn.com/docs/components/radix/button#api-reference
 ## References
 
 - [WebHaptics](https://haptics.lochie.me) by [@lochieaxon](https://x.com/lochieaxon)
-- [tiks](https://github.com/rexa-developer/tiks)
+- [tiks](https://rexa-developer.github.io/tiks) by [Rexa Developer](https://github.com/rexa-developer)
 
 <DocSponsors />

--- a/src/features/doc/content/dot-grid-spotlight.mdx
+++ b/src/features/doc/content/dot-grid-spotlight.mdx
@@ -69,4 +69,4 @@ import { DotGridSpotlight } from "@/components/dot-grid-spotlight"
 
 ## Credits
 
-- [ChatGPT](https://chatgpt.com) — inspiration from its image-generating spotlight effect.
+- [ChatGPT](https://chatgpt.com)

--- a/src/features/doc/content/elastic-slider.mdx
+++ b/src/features/doc/content/elastic-slider.mdx
@@ -171,7 +171,7 @@ When `prefers-reduced-motion` is on, rubber-band stretch and spring-based fill m
 
 ## Credits
 
-- [Slider in DialKit](https://joshpuckett.me/dialkit) by [Josh Puckett](https://joshpuckett.me)
+- [Josh Puckett](https://joshpuckett.me/dialkit)
 
 ## References
 

--- a/src/features/doc/content/fluid-gradient-text.mdx
+++ b/src/features/doc/content/fluid-gradient-text.mdx
@@ -80,4 +80,4 @@ import { FluidGradientText } from "@/components/fluid-gradient-text"
 
 ## Credits
 
-- [Vercel Design](https://vercel.com/design) — inspiration for this text gradient interaction.
+- [Vercel](https://vercel.com/design)

--- a/src/features/doc/content/github-contributions.mdx
+++ b/src/features/doc/content/github-contributions.mdx
@@ -104,7 +104,7 @@ npx shadcn@latest add @ncdai/github-contributions
 
 ## Credits
 
-- [Contribution Graph](https://www.kibo-ui.com/components/contribution-graph) by [Kibo UI](https://www.kibo-ui.com)
+- [Kibo UI](https://www.kibo-ui.com/components/contribution-graph)
 
 ## References
 

--- a/src/features/doc/content/glow-card-grid.mdx
+++ b/src/features/doc/content/glow-card-grid.mdx
@@ -165,7 +165,7 @@ const params = useDialKit("GlowCard", {
 
 ## Credits
 
-- [Original glow effect demo by @jh3yy](https://x.com/jh3yy/status/1992003440579662211)
+- [@jh3yy](https://x.com/jh3yy/status/1992003440579662211)
 
 ## References
 

--- a/src/features/doc/content/icon-swap.mdx
+++ b/src/features/doc/content/icon-swap.mdx
@@ -75,6 +75,6 @@ IconSwap
     └── {icon}
 ```
 
-## References
+## Credits
 
-- [Use blur when nothing else works](https://emilkowal.ski/ui/7-practical-animation-tips#7.-use-blur-when-nothing-else-works)
+- [Emil Kowalski](https://emilkowal.ski/ui/7-practical-animation-tips#7.-use-blur-when-nothing-else-works)

--- a/src/features/doc/content/middle-truncation.mdx
+++ b/src/features/doc/content/middle-truncation.mdx
@@ -120,6 +120,6 @@ Split text evenly in the middle when no constraints are provided.
 
 ## Credits
 
-- [Middle Truncation by @pqoqubbw](https://x.com/pqoqubbw/status/2039034994581000700)
+- [@pqoqubbw](https://x.com/pqoqubbw/status/2039034994581000700)
 
 <DocSponsors />

--- a/src/features/doc/content/mobius-loop-icon.mdx
+++ b/src/features/doc/content/mobius-loop-icon.mdx
@@ -73,6 +73,6 @@ import { MobiusLoopIcon } from "@/components/mobius-loop-icon"
 
 ## Credits
 
-- [ThinkingIndicator](https://www.fluidfunctionalism.com/docs/thinking-indicator) by [Fluid Functionalism](https://www.fluidfunctionalism.com) — inspiration for the interaction.
+- [Fluid Functionalism](https://www.fluidfunctionalism.com/docs/thinking-indicator)
 
 <DocSponsors />

--- a/src/features/doc/content/scroll-fade-effect.mdx
+++ b/src/features/doc/content/scroll-fade-effect.mdx
@@ -116,10 +116,13 @@ import { ScrollFadeEffect } from "@/components/scroll-fade-effect"
 
 <ComponentPreview name="scroll-fade-effect-demo-04" data-code-meta="{31}" />
 
+## Credits
+
+- [Rohit Singh Rawat](https://craft.rohitsinghrawat.com/crafts/scroll-timeline)
+
 ## References
 
-- [Scroll-Driven Animations](https://craft.rohitsinghrawat.com/crafts/scroll-timeline)
-- [Scroll Area](https://ui.shadcn.com/docs/components/scroll-area)
 - [animation-timeline](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline#browser_compatibility)
+- [Scroll Area](https://ui.shadcn.com/docs/components/scroll-area)
 
 <DocSponsors />

--- a/src/features/doc/content/spinning-circular-text.mdx
+++ b/src/features/doc/content/spinning-circular-text.mdx
@@ -125,6 +125,6 @@ so you only need to render the visible content:
 
 ## Credits
 
-- [Original ring text effect demo and source code](https://x.com/jh3yy/status/1618297458752368640) by [@jh3yy](https://x.com/jh3yy)
+- [@jh3yy](https://x.com/jh3yy/status/1618297458752368640)
 
 <DocSponsors />

--- a/src/features/doc/content/testimonials-marquee.mdx
+++ b/src/features/doc/content/testimonials-marquee.mdx
@@ -159,4 +159,8 @@ Marquee
   name="testimonials-marquee-demo-02"
 />
 
+## Credits
+
+- [Kibo UI](https://www.kibo-ui.com/components/marquee)
+
 <DocSponsors />

--- a/src/features/doc/content/theme-toggle-effect.mdx
+++ b/src/features/doc/content/theme-toggle-effect.mdx
@@ -370,7 +370,7 @@ function toggleTheme(theme: string) {
 
 ## Credits
 
-- [theme-toggle.rdsx.dev](https://theme-toggle.rdsx.dev) by [@rds_agi](https://x.com/rds_agi)
+- [@rds_agi](https://theme-toggle.rdsx.dev)
 
 ## References
 

--- a/src/features/doc/content/toc-minimap.mdx
+++ b/src/features/doc/content/toc-minimap.mdx
@@ -97,8 +97,8 @@ import { TOCMinimap } from "@/components/toc-minimap"
 
 ## Credits
 
-- [Notion](https://www.notion.com) — inspiration for compact document navigation.
-- [Vercel Knowledge Base](https://vercel.com/kb) — inspiration for minimal documentation navigation.
+- [Notion](https://www.notion.com)
+- [Vercel](https://vercel.com/kb)
 
 ## References
 

--- a/src/features/doc/content/twemoji.mdx
+++ b/src/features/doc/content/twemoji.mdx
@@ -113,7 +113,7 @@ import { Twemoji } from "@/components/twemoji"
 
 ## Credits
 
-- [Twemoji by Twitter](https://github.com/twitter/twemoji)
+- [Twitter](https://github.com/twitter/twemoji)
 
 ## References
 


### PR DESCRIPTION
…h source URLs

Standardize Credits sections across all component docs to display only author names/handles as link text while pointing URLs to exact source locations, improving attribution clarity and consistency.