### PR TITLE
refactor: simplify decorative pattern divs and remove unused cn import

### DIFF
--- a/src/app/(app)/(docs)/blog/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/blog/[slug]/page.tsx
@@ -7,7 +7,6 @@ import type { BlogPosting as PageSchema, WithContext } from "schema-dts"
 
 import { SITE_INFO, X_HANDLE } from "@/config/site"
 import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
-import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import { Prose } from "@/components/ui/typography"
@@ -238,14 +237,8 @@ export default async function Page({ params }: PageProps<"/blog/[slug]">) {
             </div>
           </div>
 
-          <div className="screen-line-top screen-line-bottom">
-            <div
-              className={cn(
-                "h-8",
-                "before:absolute before:left-[-100vw] before:-z-1 before:h-full before:w-[200vw]",
-                "before:bg-[repeating-linear-gradient(315deg,var(--pattern-foreground)_0,var(--pattern-foreground)_1px,transparent_0,transparent_50%)] before:bg-size-[10px_10px] before:[--pattern-foreground:var(--color-line)]/56"
-              )}
-            />
+          <div className="screen-line-top screen-line-bottom py-px">
+            <div className="h-4" />
           </div>
 
           <h1

--- a/src/app/(app)/(docs)/components/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/components/[slug]/page.tsx
@@ -7,7 +7,6 @@ import type { BlogPosting as PageSchema, WithContext } from "schema-dts"
 
 import { SITE_INFO, X_HANDLE } from "@/config/site"
 import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
-import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import { Prose } from "@/components/ui/typography"
@@ -253,13 +252,8 @@ export default async function Page({
             </div>
           </div>
 
-          <div className="screen-line-top screen-line-bottom">
-            <div
-              className={cn(
-                "h-8 before:absolute before:left-[-100vw] before:-z-1 before:h-full before:w-[200vw]",
-                "before:bg-[repeating-linear-gradient(315deg,var(--pattern-foreground)_0,var(--pattern-foreground)_1px,transparent_0,transparent_50%)] before:bg-size-[10px_10px] before:[--pattern-foreground:var(--color-line)]/56"
-              )}
-            />
+          <div className="screen-line-top screen-line-bottom py-px">
+            <div className="h-4" />
           </div>
 
           <h1


### PR DESCRIPTION
Remove complex CSS pattern implementation in favor of simpler spacing approach and clean up unused cn utility import from both blog and components pages