### PR TITLE
refactor: restructure component docs layout to use shared layout

### DIFF
--- a/src/app/(app)/(docs)/components/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/components/[slug]/page.tsx
@@ -20,14 +20,10 @@ import { TOCInline } from "@/components/toc-inline"
 import { TOCMinimap } from "@/components/toc-minimap"
 import { DocKeyboardShortcuts } from "@/features/doc/components/doc-keyboard-shortcuts"
 import {
-  DocContainer,
   DocContentCol,
-  DocGrid,
-  DocLeftCol,
   DocRightCol,
 } from "@/features/doc/components/doc-layout"
 import { LLMCopyButtonWithViewOptions } from "@/features/doc/components/doc-page-actions"
-import { DocPageRoot } from "@/features/doc/components/doc-page-root"
 import { DocShareMenu } from "@/features/doc/components/doc-share-menu"
 import {
   findNeighbour,
@@ -138,158 +134,156 @@ export default async function Page({
 
   return (
     <>
-      <JsonLdScript data={getPageJsonLd(doc)} />
+      <DocContentCol>
+        <JsonLdScript data={getPageJsonLd(doc)} />
 
-      <JsonLdScript
-        data={jsonLdBreadcrumbList([
-          {
-            name: "Home",
-            href: "/",
-          },
-          {
-            name: "Components",
-            href: "/components",
-          },
-          {
-            name: doc.metadata.title,
-            href: `/components/${slug}`,
-          },
-        ])}
-      />
+        <JsonLdScript
+          data={jsonLdBreadcrumbList([
+            {
+              name: "Home",
+              href: "/",
+            },
+            {
+              name: "Components",
+              href: "/components",
+            },
+            {
+              name: doc.metadata.title,
+              href: `/components/${slug}`,
+            },
+          ])}
+        />
 
-      <DocKeyboardShortcuts
-        previous={previous ? `/components/${previous.slug}` : null}
-        next={next ? `/components/${next.slug}` : null}
-      />
+        <DocKeyboardShortcuts
+          previous={previous ? `/components/${previous.slug}` : null}
+          next={next ? `/components/${next.slug}` : null}
+        />
 
-      <DocPageRoot>
-        <DocContainer>
-          <div className="screen-line-bottom h-px" />
+        <div className="screen-dashed-line-bottom after:opacity-80">
+          <div className="screen-line-bottom h-px overflow-x-clip" />
+        </div>
 
-          <div className="flex items-center justify-between p-2 pl-4">
-            <Button
-              className="h-7 gap-2 border-none px-0 text-muted-foreground hover:text-foreground hover:no-underline"
-              variant="link"
-              size="sm"
-              asChild
-            >
-              <Link href="/components">
-                <ArrowLeftIcon />
-                Components
-              </Link>
-            </Button>
+        <div className="flex items-center justify-between p-2 pl-4">
+          <Button
+            className="h-7 gap-2 border-none px-0 text-muted-foreground hover:text-foreground hover:no-underline"
+            variant="link"
+            size="sm"
+            asChild
+          >
+            <Link href="/components">
+              <ArrowLeftIcon />
+              Components
+            </Link>
+          </Button>
 
-            <div className="flex items-center gap-2">
-              <LLMCopyButtonWithViewOptions
-                markdownUrl={`/components/${doc.slug}.mdx`}
-                isComponent
-              />
+          <div className="flex items-center gap-2">
+            <LLMCopyButtonWithViewOptions
+              markdownUrl={`/components/${doc.slug}.mdx`}
+              isComponent
+            />
 
-              <DocShareMenu
-                title={doc.metadata.title}
-                url={`/components/${doc.slug}`}
-              />
+            <DocShareMenu
+              title={doc.metadata.title}
+              url={`/components/${doc.slug}`}
+            />
 
-              {previous && (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        className="size-7 border-none"
-                        variant="secondary"
-                        size="icon-sm"
-                        asChild
+            {previous && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      className="size-7 border-none"
+                      variant="secondary"
+                      size="icon-sm"
+                      asChild
+                    >
+                      <Link
+                        href={`/components/${previous.slug}`}
+                        aria-label="Previous Component"
                       >
-                        <Link
-                          href={`/components/${previous.slug}`}
-                          aria-label="Previous Component"
-                        >
-                          <ArrowLeftIcon />
-                        </Link>
-                      </Button>
-                    }
-                  />
-                  <TooltipContent className="pr-2 pl-3">
-                    <div className="flex items-center gap-3">
-                      Previous Component
-                      <Kbd>
                         <ArrowLeftIcon />
-                      </Kbd>
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              )}
+                      </Link>
+                    </Button>
+                  }
+                />
+                <TooltipContent className="pr-2 pl-3">
+                  <div className="flex items-center gap-3">
+                    Previous Component
+                    <Kbd>
+                      <ArrowLeftIcon />
+                    </Kbd>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            )}
 
-              {next && (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        className="size-7 border-none"
-                        variant="secondary"
-                        size="icon-sm"
-                        asChild
+            {next && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      className="size-7 border-none"
+                      variant="secondary"
+                      size="icon-sm"
+                      asChild
+                    >
+                      <Link
+                        href={`/components/${next.slug}`}
+                        aria-label="Next Component"
                       >
-                        <Link
-                          href={`/components/${next.slug}`}
-                          aria-label="Next Component"
-                        >
-                          <ArrowRightIcon />
-                        </Link>
-                      </Button>
-                    }
-                  />
-                  <TooltipContent className="pr-2 pl-3">
-                    <div className="flex items-center gap-3">
-                      Next Component
-                      <Kbd>
                         <ArrowRightIcon />
-                      </Kbd>
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </div>
+                      </Link>
+                    </Button>
+                  }
+                />
+                <TooltipContent className="pr-2 pl-3">
+                  <div className="flex items-center gap-3">
+                    Next Component
+                    <Kbd>
+                      <ArrowRightIcon />
+                    </Kbd>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            )}
           </div>
+        </div>
 
-          <div className="screen-line-top screen-line-bottom py-px">
+        <div className="screen-dashed-line-top screen-dashed-line-bottom before:opacity-80 after:opacity-80">
+          <div className="screen-line-top screen-line-bottom overflow-x-clip py-px">
             <div className="h-4" />
           </div>
+        </div>
 
+        <div className="screen-dashed-line-bottom after:opacity-80">
           <h1
             data-slot="doc-title"
-            className="screen-line-bottom px-4 text-3xl font-semibold tracking-tight text-balance"
+            className="screen-line-bottom overflow-x-clip px-4 text-3xl font-semibold tracking-tight text-balance"
           >
             {doc.metadata.title}
           </h1>
-        </DocContainer>
+        </div>
 
-        <DocGrid>
-          <DocLeftCol />
+        <Prose className="px-(--page-padding) pt-8 [--page-padding:--spacing(4)]">
+          <p className="text-muted-foreground">{doc.metadata.description}</p>
 
-          <DocContentCol>
-            <Prose className="px-(--page-padding) pt-8 [--page-padding:--spacing(4)]">
-              <p className="text-muted-foreground">
-                {doc.metadata.description}
-              </p>
+          <TOCInline className="lg:hidden" items={toc} />
 
-              <TOCInline className="lg:hidden" items={toc} />
+          <div>
+            <MDX code={doc.content} />
+          </div>
+        </Prose>
 
-              <div>
-                <MDX code={doc.content} />
-              </div>
-            </Prose>
+        <div className="screen-dashed-line-top before:opacity-80">
+          <div className="screen-line-top h-4 overflow-x-clip" />
+        </div>
+      </DocContentCol>
 
-            <div className="screen-line-top h-4" />
-          </DocContentCol>
-
-          <DocRightCol>
-            <div className="sticky top-[calc(var(--doc-cols-top,0)+(--spacing(3)))] translate-x-2 translate-y-3 opacity-0 in-data-doc-cols-ready:opacity-100">
-              <TOCMinimap items={toc} />
-            </div>
-          </DocRightCol>
-        </DocGrid>
-      </DocPageRoot>
+      <DocRightCol>
+        <div className="sticky top-[calc(var(--doc-cols-top,0)+(--spacing(3)))] translate-x-2 opacity-0 in-data-doc-cols-ready:opacity-100">
+          <TOCMinimap items={toc} />
+        </div>
+      </DocRightCol>
     </>
   )
 }

--- a/src/app/(app)/(docs)/components/layout.tsx
+++ b/src/app/(app)/(docs)/components/layout.tsx
@@ -1,0 +1,40 @@
+import { ComponentIcon } from "@/components/icons"
+import { DocGrid, DocLeftCol } from "@/features/doc/components/doc-layout"
+import { DocPageRoot } from "@/features/doc/components/doc-page-root"
+import { getDocsByCategory } from "@/features/doc/data/documents"
+
+import { Sidebar } from "./sidebar"
+
+export default function ComponentDocsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const componentDocs = getDocsByCategory("components")
+    .slice()
+    .sort((a, b) =>
+      a.metadata.title.localeCompare(b.metadata.title, "en", {
+        sensitivity: "base",
+      })
+    )
+
+  return (
+    <DocPageRoot>
+      <DocGrid>
+        <DocLeftCol className="pr-4 pb-3.75">
+          <div className="sticky top-[calc(var(--header-height)+(--spacing(12)))] flex h-[calc(100dvh-var(--header-height)-(--spacing(36)))] w-fit max-w-full flex-col rounded-xl border bg-background max-xl:hidden">
+            <Sidebar
+              items={componentDocs.map((doc) => ({
+                title: doc.metadata.title,
+                href: `/components/${doc.slug}`,
+                icon: <ComponentIcon variant={doc.slug} />,
+              }))}
+            />
+          </div>
+        </DocLeftCol>
+
+        {children}
+      </DocGrid>
+    </DocPageRoot>
+  )
+}

--- a/src/app/(app)/(docs)/components/sidebar.tsx
+++ b/src/app/(app)/(docs)/components/sidebar.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+import { cn } from "@/lib/utils"
+
+type MenuItem = {
+  title: string
+  href: string
+  icon?: React.JSX.Element
+}
+
+export function Sidebar({ items }: { items: MenuItem[] }) {
+  const pathname = usePathname()
+
+  const itemActiveRef = useRef<HTMLAnchorElement | null>(null)
+
+  useEffect(() => {
+    itemActiveRef.current?.scrollIntoView({ block: "center" })
+  }, [])
+
+  return (
+    <nav className="no-scrollbar grow overflow-x-clip overflow-y-auto overscroll-contain scroll-fade-effect-y">
+      <ul className="flex flex-col gap-px p-1">
+        {items.map((item) => {
+          const isActive = item.href === pathname
+          return (
+            <li key={item.href}>
+              <Link
+                ref={isActive ? itemActiveRef : null}
+                data-active={isActive}
+                className={cn(
+                  "flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm",
+                  "hover:bg-sidebar-accent data-active:bg-sidebar-accent",
+                  "[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:text-muted-foreground"
+                )}
+                href={item.href}
+              >
+                {item.icon}
+                <span className="line-clamp-1">{item.title}</span>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/src/components/toc-minimap.tsx
+++ b/src/components/toc-minimap.tsx
@@ -41,8 +41,8 @@ export function TOCMinimap({
           }}
         >
           <HoverCardTrigger
-            delay={0}
-            closeDelay={0}
+            delay={0.1}
+            closeDelay={0.1}
             render={
               <div className="flex max-h-[calc(100dvh-var(--doc-cols-top,0)+(--spacing(-24)))] flex-col gap-3 overflow-hidden py-3 pl-6 opacity-100 transition-opacity duration-200 data-popup-open:opacity-0">
                 <Minimap />

--- a/src/features/doc/components/doc-layout.tsx
+++ b/src/features/doc/components/doc-layout.tsx
@@ -32,9 +32,9 @@ export function DocGrid({ className, ...props }: React.ComponentProps<"div">) {
 export function DocLeftCol({
   className,
   ...props
-}: React.ComponentProps<"div">) {
+}: React.ComponentProps<"aside">) {
   return (
-    <div
+    <aside
       data-slot="doc-left-col"
       className={cn("max-lg:hidden", className)}
       {...props}
@@ -51,9 +51,9 @@ export function DocContentCol(
 export function DocRightCol({
   className,
   ...props
-}: React.ComponentProps<"div">) {
+}: React.ComponentProps<"aside">) {
   return (
-    <div
+    <aside
       data-slot="doc-right-col"
       className={cn("max-lg:hidden", className)}
       {...props}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -169,26 +169,42 @@
 }
 
 @utility screen-line-top {
-  @apply relative before:absolute before:top-0 before:left-[-100vw] before:-z-1 before:h-px before:w-[200vw] before:bg-line;
+  @apply relative;
+  &:before {
+    @apply absolute top-0 left-[-100vw] -z-1 h-px w-[200vw] bg-line;
+    content: "";
+  }
 }
 
 @utility screen-dashed-line-top {
-  @apply relative before:absolute before:top-0 before:left-[-100vw] before:-z-1 before:h-px before:w-[200vw] before:border-t before:border-dashed before:border-line;
+  @apply screen-line-top;
+  &:before {
+    @apply bg-inherit bg-[linear-gradient(to_right,var(--line)_60%,transparent_40%)] bg-size-[8px_1px] bg-repeat-x;
+    content: "";
+  }
 }
 
 @utility screen-line-bottom {
-  @apply relative after:absolute after:bottom-0 after:left-[-100vw] after:-z-1 after:h-px after:w-[200vw] after:bg-line;
+  @apply relative;
+  &:after {
+    @apply absolute bottom-0 left-[-100vw] -z-1 h-px w-[200vw] bg-line;
+    content: "";
+  }
 }
 
 @utility screen-dashed-line-bottom {
-  @apply relative after:absolute after:bottom-0 after:left-[-100vw] after:-z-1 after:h-px after:w-[200vw] after:border-b after:border-dashed after:border-line;
+  @apply screen-line-bottom;
+  &:after {
+    @apply bg-inherit bg-[linear-gradient(to_right,var(--line)_60%,transparent_40%)] bg-size-[8px_1px] bg-repeat-x;
+    content: "";
+  }
 }
 
 @utility step {
   @apply max-md:pl-10;
   counter-increment: step;
 
-  &::before {
+  &:before {
     @apply absolute inline-flex size-6 items-center justify-center rounded-lg bg-muted text-center indent-0 text-[0.8125rem]/6 font-normal text-foreground max-md:left-0 md:-ml-10;
     content: counter(step);
   }


### PR DESCRIPTION
Remove unused layout components from individual page and create dedicated layout.tsx with sidebar navigation. Move DocGrid and DocLeftCol to layout level for consistent structure across all component pages.

feat: add sidebar navigation for component documentation

Create new Sidebar component with auto-scroll to active item and ComponentIcon integration for better navigation experience.

style: improve screen line utilities with proper CSS implementation

Replace border-based dashed lines with background gradient patterns and add overflow-x-clip for better visual consistency.

fix: adjust TOC minimap hover delays for better UX

Increase hover card delay from 0 to 0.1 seconds to prevent accidental triggers during mouse movement.