### PR TITLE
style: update dashed line patterns to use smaller segments

### DIFF
--- a/src/features/portfolio/components/overview/index.tsx
+++ b/src/features/portfolio/components/overview/index.tsx
@@ -83,7 +83,7 @@ export function Overview() {
       </PanelContent>
 
       <div
-        className="pointer-events-none absolute top-px bottom-0 left-1/2 -z-1 w-px -translate-x-2.25 bg-[linear-gradient(to_bottom,var(--line)_60%,transparent_40%)] bg-size-[1px_8px] bg-repeat-y opacity-80 max-sm:hidden"
+        className="pointer-events-none absolute top-px bottom-0 left-1/2 -z-1 w-px -translate-x-2.25 bg-[linear-gradient(to_bottom,var(--line)_4px,transparent_2px)] bg-size-[1px_6px] bg-repeat-y max-sm:hidden"
         aria-hidden
       />
     </Panel>

--- a/src/features/portfolio/components/profile-cover.tsx
+++ b/src/features/portfolio/components/profile-cover.tsx
@@ -19,6 +19,7 @@ const DOT_COLOR = {
   },
 }
 
+/** @deprecated */
 export function ProfileCover() {
   const containerRef = useRef<HTMLDivElement>(null)
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -179,7 +179,7 @@
 @utility screen-dashed-line-top {
   @apply screen-line-top;
   &:before {
-    @apply bg-inherit bg-[linear-gradient(to_right,var(--line)_60%,transparent_40%)] bg-size-[8px_1px] bg-repeat-x;
+    @apply bg-inherit bg-[linear-gradient(to_right,var(--line)_4px,transparent_2px)] bg-size-[6px_1px] bg-repeat-x;
     content: "";
   }
 }
@@ -195,7 +195,7 @@
 @utility screen-dashed-line-bottom {
   @apply screen-line-bottom;
   &:after {
-    @apply bg-inherit bg-[linear-gradient(to_right,var(--line)_60%,transparent_40%)] bg-size-[8px_1px] bg-repeat-x;
+    @apply bg-inherit bg-[linear-gradient(to_right,var(--line)_4px,transparent_2px)] bg-size-[6px_1px] bg-repeat-x;
     content: "";
   }
 }


### PR DESCRIPTION
Change dashed line gradients from 60%/40% split with 8px segments to 4px/2px split with 6px segments for more refined visual appearance across overview component and CSS utilities

docs: deprecate ProfileCover component