### PR TITLE
style: add gradient border plugin and improve social links styling

### DIFF
--- a/src/features/portfolio/components/chanhdai-mark-isometric.tsx
+++ b/src/features/portfolio/components/chanhdai-mark-isometric.tsx
@@ -29,7 +29,7 @@ export function ChanhDaiMarkIsometric() {
 
   return (
     <motion.svg
-      className="h-auto w-full overflow-visible [--pattern:color-mix(in_oklab,var(--foreground)_12%,var(--background))] [--stroke:color-mix(in_oklab,var(--foreground)_16%,var(--background))]"
+      className="h-auto w-full touch-manipulation overflow-visible [--pattern:color-mix(in_oklab,var(--foreground)_12%,var(--background))] [--stroke:color-mix(in_oklab,var(--foreground)_16%,var(--background))]"
       viewBox="0 0 556 354"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/features/portfolio/components/social-links-v2.tsx
+++ b/src/features/portfolio/components/social-links-v2.tsx
@@ -24,9 +24,13 @@ export function SocialLinks() {
                   render={
                     <a
                       className={cn(
-                        "flex size-8 items-center justify-center rounded-lg border",
-                        "bg-background hover:bg-muted dark:border-input dark:hover:bg-input/50",
-                        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-foreground [&_svg:not([class*='size-'])]:size-5"
+                        "flex size-8 items-center justify-center rounded-lg",
+                        "gradient-border gradient-border-to-tl",
+                        "gradient-border-from-foreground/10 gradient-border-to-foreground/20 gradient-border-via-foreground/5",
+                        "dark:gradient-border-from-foreground/20 dark:gradient-border-to-foreground/30 dark:gradient-border-via-foreground/6",
+                        "bg-linear-to-t from-zinc-100 to-zinc-50 dark:from-zinc-900 dark:to-zinc-800",
+                        "shadow-[inset_0_-1px_1px_1px] shadow-white dark:shadow-[inset_0_1px_1px_0px] dark:shadow-zinc-900",
+                        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-foreground/80 [&_svg]:drop-shadow-xs [&_svg]:drop-shadow-foreground/15 [&_svg:not([class*='size-'])]:size-5"
                       )}
                       href={addQueryParams(item.href, UTM_PARAMS)}
                       target="_blank"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,7 @@
 @import "tw-animate-css";
 @import "./style-preview.css";
 @import "./scroll-fade-effect.css";
+@import "./gradient-border-plugin.css";
 
 @plugin "@tailwindcss/typography";
 

--- a/src/styles/gradient-border-plugin.css
+++ b/src/styles/gradient-border-plugin.css
@@ -1,0 +1,185 @@
+/**
+ * TailwindCSS gradient border plugin.
+ *
+ * @author Florian Kiem <https://github.com/flornkm>
+ * @license MIT
+ */
+
+@theme {
+  --gradient-border-width-1: 1px;
+  --gradient-border-width-2: 2px;
+  --gradient-border-width-3: 3px;
+  --gradient-border-width-4: 4px;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Base utility — default 1px gradient border                         */
+/* ------------------------------------------------------------------ */
+
+@utility gradient-border {
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: var(--gradient-border-width, 1px);
+    background: var(
+      --gradient-border,
+      linear-gradient(
+        var(--gradient-border-angle, to bottom),
+        var(--gradient-border-from, rgba(0, 0, 0, 0.15)),
+        var(
+          --gradient-border-via,
+          var(--gradient-border-from, rgba(0, 0, 0, 0.15))
+        ),
+        var(--gradient-border-to, transparent)
+      )
+    );
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    mask-composite: exclude;
+    pointer-events: none;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Width variants — gradient-border-2, gradient-border-3, etc.        */
+/* ------------------------------------------------------------------ */
+
+@utility gradient-border-* {
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: --value(--gradient-border-width-*);
+    background: var(
+      --gradient-border,
+      linear-gradient(
+        var(--gradient-border-angle, to bottom),
+        var(--gradient-border-from, rgba(0, 0, 0, 0.15)),
+        var(
+          --gradient-border-via,
+          var(--gradient-border-from, rgba(0, 0, 0, 0.15))
+        ),
+        var(--gradient-border-to, transparent)
+      )
+    );
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    mask-composite: exclude;
+    pointer-events: none;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Direction — mirrors bg-linear-to-* from Tailwind                   */
+/*  gradient-border-to-r, gradient-border-to-bl, etc.                  */
+/* ------------------------------------------------------------------ */
+
+@utility gradient-border-to-t {
+  --gradient-border-angle: to top;
+}
+
+@utility gradient-border-to-tr {
+  --gradient-border-angle: to top right;
+}
+
+@utility gradient-border-to-r {
+  --gradient-border-angle: to right;
+}
+
+@utility gradient-border-to-br {
+  --gradient-border-angle: to bottom right;
+}
+
+@utility gradient-border-to-b {
+  --gradient-border-angle: to bottom;
+}
+
+@utility gradient-border-to-bl {
+  --gradient-border-angle: to bottom left;
+}
+
+@utility gradient-border-to-l {
+  --gradient-border-angle: to left;
+}
+
+@utility gradient-border-to-tl {
+  --gradient-border-angle: to top left;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Color stops — mirrors from-*, via-*, to-* from Tailwind            */
+/*  gradient-border-from-blue-500, gradient-border-to-pink-300, etc.   */
+/* ------------------------------------------------------------------ */
+
+@utility gradient-border-from-* {
+  --gradient-border-from-alpha: calc(--modifier(integer) * 1%);
+  --gradient-border-from: --alpha(
+    --value(--color-*, [color]) / var(--gradient-border-from-alpha, 100%)
+  );
+}
+
+@utility gradient-border-to-* {
+  --gradient-border-to-alpha: calc(--modifier(integer) * 1%);
+  --gradient-border-to: --alpha(
+    --value(--color-*, [color]) / var(--gradient-border-to-alpha, 100%)
+  );
+}
+
+@utility gradient-border-via-* {
+  --gradient-border-via-alpha: calc(--modifier(integer) * 1%);
+  --gradient-border-via: --alpha(
+    --value(--color-*, [color]) / var(--gradient-border-via-alpha, 100%)
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Reset                                                              */
+/* ------------------------------------------------------------------ */
+
+@utility gradient-border-none {
+  &::before {
+    content: none !important;
+    background: none !important;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  animate-gradient-border — rotates the angle of whatever gradient   */
+/*  the element already has. Pairs with any combination of the         */
+/*  from, via, and to color utilities. Override speed via              */
+/*  --gradient-border-duration (default 4s).                           */
+/* ------------------------------------------------------------------ */
+
+@property --gradient-border-rotation {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@keyframes gradient-border {
+  to {
+    --gradient-border-rotation: 360deg;
+  }
+}
+
+@utility animate-gradient-border {
+  --gradient-border-angle: var(--gradient-border-rotation);
+  animation: gradient-border var(--gradient-border-duration, 4s) linear infinite;
+}


### PR DESCRIPTION
Add gradient border CSS plugin with utilities for width, direction, and color stops. Update social links to use gradient borders with enhanced visual styling including shadows and background gradients. Add touch-manipulation to isometric mark for better mobile interaction.