### PR TITLE
feat: add grayscale filter to images with smooth hover transition

### DIFF
--- a/src/features/blog/components/post-item.tsx
+++ b/src/features/blog/components/post-item.tsx
@@ -19,11 +19,11 @@ export function PostItem({
   const Heading = headingAs ?? "h2"
 
   return (
-    <div className="relative flex h-full flex-col gap-2 p-2 transition-[background-color] ease-out hover:bg-accent-muted">
+    <div className="group/post relative flex h-full flex-col gap-2 p-2 transition-[background-color] ease-out hover:bg-accent-muted">
       {post.metadata.image && (
         <div className="relative select-none [--image-radius:var(--radius-xl)]">
           <Image
-            className="aspect-1200/630 rounded-(--image-radius)"
+            className="aspect-1200/630 rounded-(--image-radius) grayscale transition-[filter] duration-300 ease-[cubic-bezier(0.42,0,0.58,1)] group-hover/post:grayscale-0"
             src={post.metadata.image}
             alt={post.metadata.title}
             width={1200}

--- a/src/features/portfolio/components/experiences/experience-item.tsx
+++ b/src/features/portfolio/components/experiences/experience-item.tsx
@@ -10,7 +10,7 @@ export function ExperienceItem({ experience }: { experience: Experience }) {
   return (
     <div
       id={`experience-${experience.id}`}
-      className="screen-line-bottom scroll-mt-14 space-y-4 py-4"
+      className="group/experience screen-line-bottom scroll-mt-14 space-y-4 py-4"
     >
       <div className="flex items-center gap-3">
         <div className="flex size-6 shrink-0 items-center justify-center select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-5">
@@ -21,7 +21,7 @@ export function ExperienceItem({ experience }: { experience: Experience }) {
               width={24}
               height={24}
               quality={100}
-              className="rounded-full"
+              className="rounded-full grayscale transition-[filter] duration-300 ease-[cubic-bezier(0.42,0,0.58,1)] group-hover/experience:grayscale-0"
               unoptimized
               aria-hidden
             />

--- a/src/features/portfolio/components/profile-header.tsx
+++ b/src/features/portfolio/components/profile-header.tsx
@@ -35,10 +35,7 @@ export function ProfileHeader() {
               {USER.displayName}
             </h1>
 
-            <VerifiedIcon
-              className="size-4.5 text-info select-none"
-              aria-hidden
-            />
+            <VerifiedIcon className="size-4.5 select-none" aria-hidden />
 
             {USER.namePronunciationUrl && (
               <PronounceMyName

--- a/src/features/portfolio/components/projects/project-item.tsx
+++ b/src/features/portfolio/components/projects/project-item.tsx
@@ -35,7 +35,7 @@ export function ProjectItem({
 
   return (
     <Collapsible className={className} defaultOpen={project.isExpanded}>
-      <div className="flex items-center hover:bg-accent-muted">
+      <div className="group/project flex items-center hover:bg-accent-muted">
         {project.logo ? (
           <Image
             src={project.logo}
@@ -43,7 +43,7 @@ export function ProjectItem({
             width={32}
             height={32}
             quality={100}
-            className="mx-4 flex size-6 shrink-0 select-none"
+            className="mx-4 flex size-6 shrink-0 grayscale select-none group-hover/project:grayscale-0"
             unoptimized
             aria-hidden
           />

--- a/src/features/portfolio/components/testimonials.tsx
+++ b/src/features/portfolio/components/testimonials.tsx
@@ -133,7 +133,7 @@ function TestimonialItem({
     <Testimonial className="group/testimonial relative">
       <TestimonialQuote className="font-serif text-base">
         <p>
-          <Twemoji className="grayscale transition-[filter] duration-300 group-hover/testimonial:grayscale-0">
+          <Twemoji className="grayscale transition-[filter] duration-300 ease-[cubic-bezier(0.42,0,0.58,1)] group-hover/testimonial:grayscale-0">
             {quote}
           </Twemoji>
         </p>
@@ -142,7 +142,7 @@ function TestimonialItem({
       <TestimonialAuthor>
         <TestimonialAvatar>
           <TestimonialAvatarImg
-            className="grayscale transition-[filter] duration-300 group-hover/testimonial:grayscale-0"
+            className="grayscale transition-[filter] duration-300 ease-[cubic-bezier(0.42,0,0.58,1)] group-hover/testimonial:grayscale-0"
             src={authorAvatar}
             alt={authorName}
           />


### PR DESCRIPTION
Apply grayscale filter to images in blog posts, experiences, projects, and testimonials. Images transition from grayscale to color on hover using cubic-bezier easing for a polished visual effect. Remove text-info class from VerifiedIcon to maintain consistent styling.