### PR TITLE
feat(daikanoid): replace solid color shapes with theme-aware images

### DIFF
--- a/src/components/daikanoid/ball.ts
+++ b/src/components/daikanoid/ball.ts
@@ -1,7 +1,6 @@
 import type p5 from "p5"
 
 import type { Brick } from "./brick"
-import { Colors } from "./colors"
 import { BALL_SIZE, BALL_SPEED, BRICK_SCORE, uncheckedClamp } from "./constants"
 import type { GameState } from "./types"
 
@@ -25,10 +24,8 @@ export class Ball {
   }
 
   show() {
-    // this.p.imageMode(this.p.CENTER)
-    // this.p.image(this.state.ballImage!, this.x, this.y, BALL_SIZE, BALL_SIZE)
-    this.p.fill(Colors.ball)
-    this.p.circle(this.x, this.y, BALL_SIZE)
+    this.p.imageMode(this.p.CENTER)
+    this.p.image(this.state.ballImage!, this.x, this.y, BALL_SIZE, BALL_SIZE)
   }
 
   move() {

--- a/src/components/daikanoid/colors.ts
+++ b/src/components/daikanoid/colors.ts
@@ -12,10 +12,6 @@ function initColors() {
     brick: getCSSVariable("--dk-brick"),
     brickHighlight: getCSSVariable("--dk-brick-highlight"),
     brickShadow: getCSSVariable("--dk-brick-shadow"),
-    ball: getCSSVariable("--dk-ball"),
-    paddle: getCSSVariable("--dk-paddle"),
-    paddleHighlight: getCSSVariable("--dk-paddle-highlight"),
-    paddleShadow: getCSSVariable("--dk-paddle-shadow"),
   } as const
 }
 

--- a/src/components/daikanoid/component.tsx
+++ b/src/components/daikanoid/component.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect, useRef } from "react"
 import { useReducedMotion } from "motion/react"
+import { useTheme } from "next-themes"
 import p5 from "p5"
 
 import { cn } from "@/lib/utils"
@@ -12,7 +13,11 @@ import { Ball } from "./ball"
 import { resetGame } from "./brick"
 import { Colors, loadColors } from "./colors"
 import {
+  BALL_DARK_URL,
+  BALL_LIGHT_URL,
   FONT_URL,
+  PADDLE_DARK_URL,
+  PADDLE_LIGHT_URL,
   SOUND_BOUNCE_URL,
   SOUND_BREAK_URL,
   SOUND_GAME_OVER_URL,
@@ -27,6 +32,7 @@ export function Daikanoid({
 }: Omit<React.ComponentPropsWithRef<"canvas">, "children">) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const shouldReduceMotion = useReducedMotion()
+  const { resolvedTheme } = useTheme()
 
   useEffect(() => {
     loadColors()
@@ -46,8 +52,8 @@ export function Daikanoid({
       soundBreak: null,
       soundGameOver: null,
 
-      // ballImage: null,
-      // paddleImage: null,
+      ballImage: null,
+      paddleImage: null,
     }
 
     let font: p5.Font
@@ -66,8 +72,12 @@ export function Daikanoid({
         state.soundBreak = p.createAudio(SOUND_BREAK_URL)
         state.soundGameOver = p.createAudio(SOUND_GAME_OVER_URL)
 
-        // state.ballImage = p.loadImage("/assets/ball.png")
-        // state.paddleImage = p.loadImage("/assets/paddle.png")
+        state.ballImage = p.loadImage(
+          resolvedTheme === "dark" ? BALL_DARK_URL : BALL_LIGHT_URL
+        )
+        state.paddleImage = p.loadImage(
+          resolvedTheme === "dark" ? PADDLE_DARK_URL : PADDLE_LIGHT_URL
+        )
       }
 
       p.setup = () => {
@@ -148,7 +158,7 @@ export function Daikanoid({
       window.removeEventListener("keypress", handleKeyPress)
       p5Instance.remove()
     }
-  }, [shouldReduceMotion])
+  }, [shouldReduceMotion, resolvedTheme])
 
   return (
     <canvas

--- a/src/components/daikanoid/constants.ts
+++ b/src/components/daikanoid/constants.ts
@@ -1,4 +1,4 @@
-export const BALL_SIZE = 24
+export const BALL_SIZE = 21
 export const BALL_SPEED = 10
 
 export const PADDLE_WIDTH = 96
@@ -19,6 +19,16 @@ export const SOUND_BREAK_URL =
   "https://assets.chanhdai.com/sounds/daikanoid/break.mp3"
 export const SOUND_GAME_OVER_URL =
   "https://assets.chanhdai.com/sounds/daikanoid/game-over.mp3"
+
+export const BALL_LIGHT_URL =
+  "https://assets.chanhdai.com/images/daikanoid/ball-light.png?v=2"
+export const BALL_DARK_URL =
+  "https://assets.chanhdai.com/images/daikanoid/ball-dark.png?v=2"
+
+export const PADDLE_LIGHT_URL =
+  "https://assets.chanhdai.com/images/daikanoid/paddle-light.png?v=2"
+export const PADDLE_DARK_URL =
+  "https://assets.chanhdai.com/images/daikanoid/paddle-dark.png?v=2"
 
 export function uncheckedClamp(
   min: number,

--- a/src/components/daikanoid/daikanoid.css
+++ b/src/components/daikanoid/daikanoid.css
@@ -6,12 +6,6 @@
   --dk-brick: #a1a1aa;
   --dk-brick-highlight: rgba(255, 255, 255, 0.5);
   --dk-brick-shadow: #71717a;
-
-  --dk-ball: #09090b;
-
-  --dk-paddle: #a1a1aa;
-  --dk-paddle-highlight: rgba(255, 255, 255, 0.5);
-  --dk-paddle-shadow: #71717a;
 }
 
 .dark {
@@ -22,10 +16,4 @@
   --dk-brick: #71717a;
   --dk-brick-highlight: rgba(255, 255, 255, 0.3);
   --dk-brick-shadow: #3f3f46;
-
-  --dk-ball: #fafafa;
-
-  --dk-paddle: #71717a;
-  --dk-paddle-highlight: rgba(255, 255, 255, 0.3);
-  --dk-paddle-shadow: #3f3f46;
 }

--- a/src/components/daikanoid/paddle.ts
+++ b/src/components/daikanoid/paddle.ts
@@ -1,6 +1,5 @@
 import type p5 from "p5"
 
-import { Colors } from "./colors"
 import {
   PADDLE_HEIGHT,
   PADDLE_SPEED,
@@ -56,23 +55,23 @@ export class Paddle {
   }
 
   show() {
-    // this.p.imageMode(this.p.CORNER)
-    // this.p.image(
-    //   this.state.paddleImage!,
-    //   this.x,
-    //   this.y,
-    //   PADDLE_WIDTH,
-    //   PADDLE_HEIGHT
-    // )
+    this.p.imageMode(this.p.CORNER)
+    this.p.image(
+      this.state.paddleImage!,
+      this.x,
+      this.y,
+      PADDLE_WIDTH,
+      PADDLE_HEIGHT
+    )
 
-    this.p.fill(Colors.paddle)
-    this.p.rect(this.x, this.y, PADDLE_WIDTH, PADDLE_HEIGHT)
+    // this.p.fill(Colors.paddle)
+    // this.p.rect(this.x, this.y, PADDLE_WIDTH, PADDLE_HEIGHT)
 
-    this.p.fill(Colors.paddleHighlight)
-    this.p.rect(this.x, this.y + 3, PADDLE_WIDTH, 3)
+    // this.p.fill(Colors.paddleHighlight)
+    // this.p.rect(this.x, this.y + 3, PADDLE_WIDTH, 3)
 
-    this.p.fill(Colors.paddleShadow)
-    this.p.rect(this.x, this.y + PADDLE_HEIGHT - 3, PADDLE_WIDTH, 3)
+    // this.p.fill(Colors.paddleShadow)
+    // this.p.rect(this.x, this.y + PADDLE_HEIGHT - 3, PADDLE_WIDTH, 3)
   }
 
   move() {

--- a/src/components/daikanoid/types.ts
+++ b/src/components/daikanoid/types.ts
@@ -14,6 +14,6 @@ export interface GameState {
   soundBounce: p5.MediaElement | null
   soundBreak: p5.MediaElement | null
   soundGameOver: p5.MediaElement | null
-  // ballImage: p5.Image | null
-  // paddleImage: p5.Image | null
+  ballImage: p5.Image | null
+  paddleImage: p5.Image | null
 }


### PR DESCRIPTION
Replace solid color ball and paddle with image assets that adapt to light/dark theme. Load appropriate image variants based on resolvedTheme and remove unused CSS color variables for ball and paddle elements.