### PR TITLE
feat(portfolio): add location and location type to experience items

### DIFF
--- a/src/features/portfolio/components/experiences/experience-item.tsx
+++ b/src/features/portfolio/components/experiences/experience-item.tsx
@@ -12,7 +12,7 @@ export function ExperienceItem({ experience }: { experience: Experience }) {
       id={`experience-${experience.id}`}
       className="group/experience screen-line-bottom scroll-mt-14 space-y-4 py-4"
     >
-      <div className="flex items-center gap-3">
+      <div className="flex items-start gap-3 sm:items-center">
         <div className="flex size-6 shrink-0 items-center justify-center select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-5">
           {experience.companyLogo ? (
             <Image
@@ -32,28 +32,48 @@ export function ExperienceItem({ experience }: { experience: Experience }) {
           )}
         </div>
 
-        <h3 className="text-lg leading-snug font-semibold">
-          {experience.companyWebsite ? (
-            <a
-              className="link"
-              href={addQueryParams(experience.companyWebsite, UTM_PARAMS)}
-              target="_blank"
-              rel="noopener"
-            >
-              {experience.companyName}
-            </a>
-          ) : (
-            experience.companyName
-          )}
-        </h3>
+        <div className="flex min-w-0 flex-1 flex-col gap-x-3 gap-y-1 pr-1 sm:flex-row sm:items-baseline sm:justify-between">
+          <h3 className="text-xl/6 font-medium">
+            {experience.companyWebsite ? (
+              <a
+                className="link"
+                href={addQueryParams(experience.companyWebsite, UTM_PARAMS)}
+                target="_blank"
+                rel="noopener"
+              >
+                {experience.companyName}
+              </a>
+            ) : (
+              experience.companyName
+            )}
+          </h3>
 
-        {experience.isCurrentEmployer && (
-          <span className="relative flex items-center justify-center">
-            <span className="absolute inline-flex size-3 animate-ping rounded-full bg-info opacity-50" />
-            <span className="relative inline-flex size-2 rounded-full bg-info" />
-            <span className="sr-only">Current Employer</span>
-          </span>
-        )}
+          {experience.location && experience.locationType && (
+            <dl className="flex min-w-0 items-center gap-1.5 text-sm whitespace-nowrap text-muted-foreground">
+              <dt className="sr-only">Location</dt>
+              <dd className="truncate">{experience.location}</dd>
+
+              <dt className="sr-only">Location type</dt>
+              <dd>({experience.locationType})</dd>
+
+              {experience.isCurrentEmployer && (
+                <>
+                  <dt className="sr-only">Employment status</dt>
+                  <dd>
+                    <span className="sr-only">Current</span>
+                    <span
+                      className="relative flex size-2.5 translate-x-px translate-y-px items-center justify-center"
+                      aria-hidden
+                    >
+                      <span className="absolute inline-flex size-2.5 animate-ping rounded-full bg-info opacity-50" />
+                      <span className="relative inline-flex size-1.5 rounded-full bg-info" />
+                    </span>
+                  </dd>
+                </>
+              )}
+            </dl>
+          )}
+        </div>
       </div>
 
       <div className="relative space-y-4 before:absolute before:left-3 before:h-full before:w-px before:bg-border">

--- a/src/features/portfolio/data/experiences.tsx
+++ b/src/features/portfolio/data/experiences.tsx
@@ -14,6 +14,8 @@ export const EXPERIENCES: Experience[] = [
     companyName: "shadcncraft",
     companyLogo: "https://assets.chanhdai.com/images/companies/shadcncraft.svg",
     companyWebsite: "https://shadcncraft.com?atp=ncdai",
+    location: "Melbourne, Australia",
+    locationType: "Remote",
     positions: [
       {
         id: "1",
@@ -48,6 +50,8 @@ export const EXPERIENCES: Experience[] = [
     companyName: "Quaric",
     companyLogo: "https://assets.chanhdai.com/images/companies/quaric.svg",
     companyWebsite: "https://quaric.com",
+    location: "Can Tho, Viet Nam",
+    locationType: "Remote",
     positions: [
       {
         id: "2",
@@ -104,6 +108,8 @@ In-house Project: [ZaDark](https://zadark.com)
     id: "simplamo",
     companyName: "Simplamo",
     companyLogo: "https://assets.chanhdai.com/images/companies/simplamo.webp",
+    location: "Ho Chi Minh City, Viet Nam",
+    locationType: "On-site",
     positions: [
       {
         id: "2",
@@ -158,6 +164,8 @@ In-house Project: [ZaDark](https://zadark.com)
     id: "tungtung",
     companyName: "Tung Tung",
     companyLogo: "https://assets.chanhdai.com/images/companies/tungtung.webp",
+    location: "Ho Chi Minh City, Viet Nam",
+    locationType: "Hybrid",
     positions: [
       {
         id: "3",

--- a/src/features/portfolio/types/experiences.ts
+++ b/src/features/portfolio/types/experiences.ts
@@ -30,6 +30,8 @@ export type Experience = {
   companyIcon?: React.ReactElement
   /** URL to the company's website. */
   companyWebsite?: string
+  location?: string
+  locationType?: "On-site" | "Hybrid" | "Remote"
   /** Roles held at this company; keep newest first for display. */
   positions: ExperiencePosition[]
   /** Marks the company as the current employer for highlighting. */


### PR DESCRIPTION
Display company location and work arrangement (On-site/Hybrid/Remote) in experience items. Restructure layout to show location info alongside company name with responsive design. Move current employer indicator into location section for better visual hierarchy. Add semantic HTML with description lists for accessibility.