### PR TITLE
feat(portfolio): add session duration metric to insights panel

### DIFF
--- a/src/features/portfolio/components/insights.tsx
+++ b/src/features/portfolio/components/insights.tsx
@@ -1,3 +1,4 @@
+import { formatDuration } from "@/utils/format"
 import { format } from "date-fns"
 
 import { cn } from "@/lib/utils"
@@ -36,12 +37,13 @@ export async function Insights() {
       </PanelHeader>
 
       <div className="relative">
-        <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-2 sm:grid-cols-3">
+        <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-2 md:grid-cols-4">
           <div className="border-r border-line" />
-          <div className="border-r border-line max-sm:hidden" />
+          <div className="border-r border-line max-md:hidden" />
+          <div className="border-r border-line max-md:hidden" />
         </div>
 
-        <dl className="grid grid-cols-2 sm:grid-cols-3">
+        <dl className="grid grid-cols-2 md:grid-cols-4">
           <Metric>
             <MetricLabel>Unique visitors</MetricLabel>
             <MetricValue>
@@ -60,6 +62,13 @@ export async function Insights() {
             <MetricLabel>Views</MetricLabel>
             <MetricValue>
               {data.summary.total_screen_views.toLocaleString()}
+            </MetricValue>
+          </Metric>
+
+          <Metric>
+            <MetricLabel>Session duration</MetricLabel>
+            <MetricValue>
+              {formatDuration(data.summary.avg_session_duration)}
             </MetricValue>
           </Metric>
         </dl>

--- a/src/features/portfolio/data/insights.ts
+++ b/src/features/portfolio/data/insights.ts
@@ -8,6 +8,7 @@ type InsightsSummary = {
   unique_visitors: number
   total_sessions: number
   total_screen_views: number
+  avg_session_duration: number
 }
 
 type InsightsSeriesItem = {

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,34 @@
+import { formatDuration } from "@/utils/format"
+import { describe, expect, it } from "vitest"
+
+describe("formatDuration", () => {
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(323)).toBe("5m 23s")
+  })
+
+  it("formats hours, minutes and seconds", () => {
+    expect(formatDuration(3661)).toBe("1h 1m 1s")
+  })
+
+  it("omits zero-valued units", () => {
+    expect(formatDuration(3600)).toBe("1h")
+    expect(formatDuration(360)).toBe("6m")
+    expect(formatDuration(45)).toBe("45s")
+  })
+
+  it("skips intermediate zero units", () => {
+    expect(formatDuration(3605)).toBe("1h 5s")
+  })
+
+  it("rounds fractional seconds", () => {
+    expect(formatDuration(323.6)).toBe("5m 24s")
+  })
+
+  it("rounds up across the minute boundary", () => {
+    expect(formatDuration(59.6)).toBe("1m")
+  })
+
+  it("handles zero", () => {
+    expect(formatDuration(0)).toBe("0s")
+  })
+})

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,17 @@
+/**
+ * Formats a duration given in seconds into a compact `Xh Ym Zs` string.
+ * Zero-valued units are omitted; a zero duration renders as `0s`.
+ */
+export function formatDuration(seconds: number): string {
+  const totalSeconds = Math.round(seconds)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const secs = totalSeconds % 60
+
+  const parts: string[] = []
+  if (hours > 0) parts.push(`${hours}h`)
+  if (minutes > 0) parts.push(`${minutes}m`)
+  if (secs > 0) parts.push(`${secs}s`)
+
+  return parts.length > 0 ? parts.join(" ") : "0s"
+}


### PR DESCRIPTION
Add average session duration display to the portfolio insights component. Implement formatDuration utility to convert seconds into human-readable format (e.g., "5m 23s"). Expand insights grid from 3 to 4 columns on medium screens to accommodate the new metric.