### PR TITLE
refactor(doc): centralize DocSponsors component placement in page

### DIFF
--- a/src/app/(app)/(docs)/components/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/components/[slug]/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/features/doc/components/doc-layout"
 import { LLMCopyButtonWithViewOptions } from "@/features/doc/components/doc-page-actions"
 import { DocShareMenu } from "@/features/doc/components/doc-share-menu"
+import { DocSponsors } from "@/features/doc/components/doc-sponsors"
 import {
   findNeighbour,
   getComponentDocs,
@@ -286,6 +287,8 @@ export default async function Page({
             <MDX code={doc.content} />
           </div>
         </Prose>
+
+        <DocSponsors />
 
         <div className="screen-dashed-line-top before:opacity-80">
           <div className="screen-line-top h-4 overflow-x-clip" />

--- a/src/features/doc/components/doc-sponsors.tsx
+++ b/src/features/doc/components/doc-sponsors.tsx
@@ -9,8 +9,6 @@ import { trackEvent } from "@/lib/events"
 import { Button } from "@/components/base/ui/button"
 import { SPONSORS } from "@/features/sponsor/data"
 
-const GOLD_SPONSORS = SPONSORS.filter((sponsor) => sponsor.tier === "gold")
-
 export function DocSponsors() {
   const [visible, setVisible] = useState(true)
 
@@ -19,47 +17,57 @@ export function DocSponsors() {
   }
 
   return (
-    <aside
-      className="not-prose my-[2.5em] rounded-xl bg-surface p-1 pt-0 inset-ring-1 inset-ring-border/64"
-      aria-labelledby="doc-sponsors-heading"
-    >
-      <div className="flex items-center justify-between pt-1 pb-0.75 pl-3">
-        <h2
-          id="doc-sponsors-heading"
-          className="font-heading text-sm/none font-medium text-muted-foreground"
-        >
-          Gold Sponsors
-        </h2>
-
-        <Button
-          aria-label="Close"
-          className="size-7 rounded-lg border-none text-muted-foreground"
-          variant="ghost"
-          size="icon-sm"
-          onClick={() => {
-            trackEvent({ name: "doc_sponsors_close" })
-            setVisible(false)
-          }}
-        >
-          <XIcon />
-        </Button>
+    <>
+      <div className="screen-dashed-line-top before:opacity-80">
+        <div className="screen-line-top h-px overflow-x-clip" />
       </div>
 
-      <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2">
-        {GOLD_SPONSORS.map((item) => (
-          <li key={item.name}>
-            <a
-              className="flex items-center justify-center rounded-[9px] border bg-background text-foreground [&_svg]:w-full [&_svg]:max-w-75 [&_svg]:shrink-0"
-              href={addQueryParams(item.url, UTM_PARAMS)}
-              target="_blank"
-              rel="noopener sponsored"
-              aria-label={`${item.name} logo`}
+      <div className="p-4">
+        <aside
+          className="rounded-xl bg-surface p-1 pt-0 inset-ring-1 inset-ring-border/64"
+          aria-labelledby="doc-sponsors-heading"
+        >
+          <div className="flex items-center justify-between pt-1 pb-0.75 pl-3">
+            <h2
+              id="doc-sponsors-heading"
+              className="font-heading text-sm/none font-medium text-muted-foreground"
             >
-              <item.logo aria-hidden />
-            </a>
-          </li>
-        ))}
-      </ul>
-    </aside>
+              Sponsors
+            </h2>
+
+            <Button
+              aria-label="Close"
+              className="size-7 rounded-lg border-none text-muted-foreground"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => {
+                trackEvent({ name: "doc_sponsors_close" })
+                setVisible(false)
+              }}
+            >
+              <XIcon />
+            </Button>
+          </div>
+
+          <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+            {SPONSORS.filter(
+              (sponsor) => sponsor.tier === "gold" || sponsor.tier === "silver"
+            ).map((item) => (
+              <li key={item.name}>
+                <a
+                  className="flex items-center justify-center rounded-[9px] border bg-background text-foreground [&_svg]:w-full [&_svg]:max-w-75 [&_svg]:shrink-0"
+                  href={addQueryParams(item.url, UTM_PARAMS)}
+                  target="_blank"
+                  rel="noopener sponsored"
+                  aria-label={`${item.name} logo`}
+                >
+                  <item.logo aria-hidden />
+                </a>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      </div>
+    </>
   )
 }

--- a/src/features/doc/content/components/apple-hello-effect.mdx
+++ b/src/features/doc/content/components/apple-hello-effect.mdx
@@ -134,5 +134,3 @@ import { AppleHelloEffectVietnamese } from "@/components/apple-hello-effect-viet
 
 - [SVG pathLength](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pathLength)
 - [React Motion component](https://motion.dev/docs/react-motion-component)
-
-<DocSponsors />

--- a/src/features/doc/content/components/brand-assets-menu.mdx
+++ b/src/features/doc/content/components/brand-assets-menu.mdx
@@ -95,5 +95,3 @@ import { BrandAssetsMenu } from "@/components/brand-assets-menu"
   path="src/registry/components/brand-assets-menu/brand-assets-menu.tsx"
   name="BrandAssetsMenuProps"
 />
-
-<DocSponsors />

--- a/src/features/doc/content/components/chevrons-up-down-icon.mdx
+++ b/src/features/doc/content/components/chevrons-up-down-icon.mdx
@@ -79,5 +79,3 @@ chevronsUpDownIconRef.current?.stopAnimation() // morph back to chevrons-up-down
 ## Credits
 
 - [Lucide](https://lucide.dev/icons/chevrons-up-down)
-
-<DocSponsors />

--- a/src/features/doc/content/components/code-block-command.mdx
+++ b/src/features/doc/content/components/code-block-command.mdx
@@ -171,5 +171,3 @@ Track user interactions with analytics services like [PostHog](https://posthog.c
   }}
 />
 ```
-
-<DocSponsors />

--- a/src/features/doc/content/components/consent-manager.mdx
+++ b/src/features/doc/content/components/consent-manager.mdx
@@ -97,5 +97,3 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 ```
 
 For customization and advanced usage, see [c15t’s documentation](https://c15t.com/docs/frameworks/next/quickstart).
-
-<DocSponsors />

--- a/src/features/doc/content/components/copy-button.mdx
+++ b/src/features/doc/content/components/copy-button.mdx
@@ -102,5 +102,3 @@ See [shadcn/ui](https://ui.shadcn.com/docs/components/radix/button#api-reference
 
 - [WebHaptics](https://haptics.lochie.me) by [@lochieaxon](https://x.com/lochieaxon)
 - [tiks](https://rexa-developer.github.io/tiks) by [Rexa Developer](https://github.com/rexa-developer)
-
-<DocSponsors />

--- a/src/features/doc/content/components/elastic-slider.mdx
+++ b/src/features/doc/content/components/elastic-slider.mdx
@@ -175,5 +175,3 @@ When `prefers-reduced-motion` is on, rubber-band stretch and spring-based fill m
 ## References
 
 - [Creating a Slider Component](https://www.interfacecraft.dev) — Interface Craft course by Josh Puckett
-
-<DocSponsors />

--- a/src/features/doc/content/components/github-contributions.mdx
+++ b/src/features/doc/content/components/github-contributions.mdx
@@ -108,5 +108,3 @@ npx shadcn@latest add @ncdai/github-contributions
 ## References
 
 - [GitHub Contributions API](https://github.com/grubersjoe/github-contributions-api) by [Jonathan Gruber](https://jogruber.de)
-
-<DocSponsors />

--- a/src/features/doc/content/components/github-stars.mdx
+++ b/src/features/doc/content/components/github-stars.mdx
@@ -78,5 +78,3 @@ import { GithubStars } from "@/components/github-stars"
 ### Fetching GitHub stars with server component
 
 <ComponentSource src="src/components/nav-item-github.tsx" collapsible="false" />
-
-<DocSponsors />

--- a/src/features/doc/content/components/glow-card-grid.mdx
+++ b/src/features/doc/content/components/glow-card-grid.mdx
@@ -169,5 +169,3 @@ const params = useDialKit("GlowCard", {
 ## References
 
 - [DialKit](https://joshpuckett.me/dialkit)
-
-<DocSponsors />

--- a/src/features/doc/content/components/haptic.mdx
+++ b/src/features/doc/content/components/haptic.mdx
@@ -63,5 +63,3 @@ import { haptic } from "@/lib/haptic"
 ## API reference
 
 <AutoTypeTable path="src/features/doc/content/props.ts" name="HapticProps" />
-
-<DocSponsors />

--- a/src/features/doc/content/components/line-nav.mdx
+++ b/src/features/doc/content/components/line-nav.mdx
@@ -138,5 +138,3 @@ Items render as plain anchors to stay framework-agnostic. For client-side naviga
 
 - [Devouring Details](https://devouringdetails.com)
 - [Skiper UI](https://skiper-ui.com)
-
-<DocSponsors />

--- a/src/features/doc/content/components/logos-carousel.mdx
+++ b/src/features/doc/content/components/logos-carousel.mdx
@@ -88,5 +88,3 @@ When `prefers-reduced-motion` is on, the staggered wave, slide, and blur transit
 ## Credits
 
 - [Devouring Details](https://devouringdetails.com)
-
-<DocSponsors />

--- a/src/features/doc/content/components/middle-truncation.mdx
+++ b/src/features/doc/content/components/middle-truncation.mdx
@@ -120,5 +120,3 @@ Split text evenly in the middle when no constraints are provided.
 ## Credits
 
 - [@pqoqubbw](https://x.com/pqoqubbw/status/2039034994581000700)
-
-<DocSponsors />

--- a/src/features/doc/content/components/mobius-loop-icon.mdx
+++ b/src/features/doc/content/components/mobius-loop-icon.mdx
@@ -72,5 +72,3 @@ import { MobiusLoopIcon } from "@/components/mobius-loop-icon"
 ## Credits
 
 - [Fluid Functionalism](https://www.fluidfunctionalism.com/docs/thinking-indicator)
-
-<DocSponsors />

--- a/src/features/doc/content/components/react-wheel-picker.mdx
+++ b/src/features/doc/content/components/react-wheel-picker.mdx
@@ -141,5 +141,3 @@ WheelPickerWrapper
   name="wheel-picker-form-demo"
   openInV0Url="https://chanhdai.com/r/wheel-picker.json"
 />
-
-<DocSponsors />

--- a/src/features/doc/content/components/scroll-fade-effect.mdx
+++ b/src/features/doc/content/components/scroll-fade-effect.mdx
@@ -128,5 +128,3 @@ import { ScrollFadeEffect } from "@/components/scroll-fade-effect"
 
 - [animation-timeline](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline#browser_compatibility)
 - [Scroll Area](https://ui.shadcn.com/docs/components/scroll-area)
-
-<DocSponsors />

--- a/src/features/doc/content/components/share-menu.mdx
+++ b/src/features/doc/content/components/share-menu.mdx
@@ -91,5 +91,3 @@ import { ShareMenu } from "@/components/share-menu"
 ## References
 
 - [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Share_API)
-
-<DocSponsors />

--- a/src/features/doc/content/components/shimmering-text.mdx
+++ b/src/features/doc/content/components/shimmering-text.mdx
@@ -103,5 +103,3 @@ CSS Variables explanation:
 
 - `--color`: Base text color (the default/resting state of characters)
 - `--shimmering-color`: Peak highlight color (the bright color characters transition to during the shimmer effect)
-
-<DocSponsors />

--- a/src/features/doc/content/components/slide-to-unlock.mdx
+++ b/src/features/doc/content/components/slide-to-unlock.mdx
@@ -146,5 +146,3 @@ SlideToUnlock
 ### Custom handle
 
 <ComponentPreview name="slide-to-unlock-demo-03" remountOnThemeChange />
-
-<DocSponsors />

--- a/src/features/doc/content/components/spinning-circular-text.mdx
+++ b/src/features/doc/content/components/spinning-circular-text.mdx
@@ -93,5 +93,3 @@ import { SpinningCircularText } from "@/components/spinning-circular-text"
 ## Credits
 
 - [@jh3yy](https://x.com/jh3yy/status/1618297458752368640)
-
-<DocSponsors />

--- a/src/features/doc/content/components/spotlight-logo.mdx
+++ b/src/features/doc/content/components/spotlight-logo.mdx
@@ -89,5 +89,3 @@ import { SpotlightLogo } from "@/components/spotlight-logo"
 - [Motion useSpring](https://motion.dev/docs/react-use-spring)
 - [SVG radialGradient](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/radialGradient)
 - [soundcn](https://www.soundcn.xyz)
-
-<DocSponsors />

--- a/src/features/doc/content/components/testimonial-2.mdx
+++ b/src/features/doc/content/components/testimonial-2.mdx
@@ -79,5 +79,3 @@ import { Testimonial2 } from "@/components/testimonial-2"
   path="src/registry/components/testimonial-2/testimonial-2.tsx"
   name="Testimonial2Props"
 />
-
-<DocSponsors />

--- a/src/features/doc/content/components/testimonial-spotlight.mdx
+++ b/src/features/doc/content/components/testimonial-spotlight.mdx
@@ -164,5 +164,3 @@ Or with inline style:
   ...
 </TestimonialSpotlight>
 ```
-
-<DocSponsors />

--- a/src/features/doc/content/components/testimonial.mdx
+++ b/src/features/doc/content/components/testimonial.mdx
@@ -113,5 +113,3 @@ Testimonial
 - [testimonials-02 block](https://chanhdai.com/blocks/marketing#testimonials-02)
 - [testimonial-spotlight](https://chanhdai.com/components/testimonial-spotlight)
 - [testimonials-marquee](https://chanhdai.com/components/testimonials-marquee)
-
-<DocSponsors />

--- a/src/features/doc/content/components/testimonials-marquee.mdx
+++ b/src/features/doc/content/components/testimonials-marquee.mdx
@@ -161,5 +161,3 @@ Marquee
 ## Credits
 
 - [Kibo UI](https://www.kibo-ui.com/components/marquee)
-
-<DocSponsors />

--- a/src/features/doc/content/components/text-flip.mdx
+++ b/src/features/doc/content/components/text-flip.mdx
@@ -77,5 +77,3 @@ import { TextFlip } from "@/components/text-flip"
   path="src/registry/components/text-flip/text-flip.tsx"
   name="TextFlipProps"
 />
-
-<DocSponsors />

--- a/src/features/doc/content/components/theme-switcher.mdx
+++ b/src/features/doc/content/components/theme-switcher.mdx
@@ -71,5 +71,3 @@ import { ThemeSwitcher } from "@/components/theme-switcher"
 - [Dark Mode with Next.js](https://ui.shadcn.com/docs/dark-mode/next)
 - [next-themes](https://github.com/pacocoursey/next-themes)
 - [Motion component](https://motion.dev/docs/react-motion-component)
-
-<DocSponsors />

--- a/src/features/doc/content/components/theme-toggle-effect.mdx
+++ b/src/features/doc/content/components/theme-toggle-effect.mdx
@@ -374,5 +374,3 @@ function toggleTheme(theme: string) {
 ## References
 
 - [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API)
-
-<DocSponsors />

--- a/src/features/doc/content/components/toc-minimap.mdx
+++ b/src/features/doc/content/components/toc-minimap.mdx
@@ -102,5 +102,3 @@ import { TOCMinimap } from "@/components/toc-minimap"
 ## References
 
 - [soundcn](https://www.soundcn.xyz) — source for the u-mini-map-open sound effect.
-
-<DocSponsors />

--- a/src/features/doc/content/components/twemoji.mdx
+++ b/src/features/doc/content/components/twemoji.mdx
@@ -117,5 +117,3 @@ import { Twemoji } from "@/components/twemoji"
 ## References
 
 - [Twemoji Parser](https://github.com/twitter/twemoji-parser)
-
-<DocSponsors />

--- a/src/features/doc/content/components/work-experience-component.mdx
+++ b/src/features/doc/content/components/work-experience-component.mdx
@@ -137,5 +137,3 @@ const experiences: ExperienceItemType[] = []
   path="src/registry/components/work-experience/work-experience.tsx"
   name="ExperiencePositionItemType"
 />
-
-<DocSponsors />


### PR DESCRIPTION
layout instead of individual MDX files

The DocSponsors component is now rendered once in the page template after the main content, eliminating the need to manually include it at the end of each component documentation file. This reduces duplication and ensures consistent sponsor placement across all component pages.