### PR TITLE
refactor(ad-unit): simplify AdUnit component styling and layout

### DIFF
--- a/src/app/(app)/(pages)/components/page.tsx
+++ b/src/app/(app)/(pages)/components/page.tsx
@@ -225,7 +225,7 @@ export default function Page() {
 
         <div className="screen-line-bottom h-px" />
 
-        <AdUnit className="screen-line-bottom p-4" slot="3900447059" />
+        <AdUnit className="screen-line-bottom" slot="3900447059" />
 
         <div className="h-4" />
       </div>

--- a/src/components/ad-unit.tsx
+++ b/src/components/ad-unit.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useRef } from "react"
 import { usePathname } from "next/navigation"
 
-import { cn } from "@/lib/utils"
-
 declare global {
   interface Window {
     adsbygoogle: unknown[]
@@ -47,26 +45,16 @@ export default function AdUnit({
   if (!ADSENSE_CLIENT) return null
 
   return (
-    <div
-      className={cn(
-        "bg-black/0.75 bg-[radial-gradient(var(--pattern-foreground)_1px,transparent_0)] bg-size-[10px_10px] bg-center [--pattern-foreground:var(--color-zinc-950)]/5 max-md:hidden dark:bg-white/0.75 dark:[--pattern-foreground:var(--color-white)]/5",
-        className
-      )}
-    >
+    <div className={className}>
       <ins
         ref={insRef}
-        className="adsbygoogle"
-        style={{ display: "block", margin: "0 auto", width: 728, height: 90 }}
+        className="adsbygoogle mx-auto block h-25 w-[320px] max-w-full overflow-hidden rounded-lg md:h-22.5 md:w-182"
+        style={{ display: "block" }}
         data-ad-client={ADSENSE_CLIENT}
         data-ad-slot={slot}
         // data-ad-format={format}
         // data-full-width-responsive={responsive}
       />
-
-      <p className="mt-4 text-center text-xs text-balance text-muted-foreground">
-        Testing ads for project sustainability. Huge thanks to the sponsors for
-        their ongoing support.
-      </p>
     </div>
   )
 }


### PR DESCRIPTION
Remove custom background pattern styling and replace with simpler responsive classes. Change ad dimensions to be responsive with mobile-first approach using Tailwind classes instead of inline styles. Remove explanatory text about ads and testing message to clean up the component presentation. Remove unused cn utility import.