### PR TITLE
style: improve visual consistency of icon rings and spacing

### DIFF
--- a/src/app/(app)/(pages)/components/component-item.tsx
+++ b/src/app/(app)/(pages)/components/component-item.tsx
@@ -27,7 +27,7 @@ export function ComponentItemIcon({
       data-slot="component-item-icon"
       className={cn(
         "relative flex size-6 shrink-0 items-center justify-center rounded-md",
-        "border border-muted-foreground/15 bg-muted ring-1 ring-line ring-offset-1 ring-offset-background",
+        "border border-muted-foreground/15 bg-muted ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
         "[&_svg]:pointer-events-none [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
         className
       )}

--- a/src/components/collapsible-list.tsx
+++ b/src/components/collapsible-list.tsx
@@ -52,7 +52,7 @@ export function CollapsibleList<T>({
       </CollapsibleContent>
 
       {items.length > max && (
-        <div className="screen-line-top -mt-px flex h-12 items-center justify-center">
+        <div className="screen-line-top -mt-px flex items-center justify-center py-4">
           <CollapsibleTrigger
             render={
               <Button

--- a/src/features/portfolio/components/awards/award-item.tsx
+++ b/src/features/portfolio/components/awards/award-item.tsx
@@ -33,7 +33,7 @@ export function AwardItem({
       <div className="flex items-center hover:bg-accent-muted">
         <div
           className={cn(
-            "mx-4 flex size-6 shrink-0 items-center justify-center rounded-md border border-muted-foreground/15 bg-muted ring-1 ring-line ring-offset-1 ring-offset-background",
+            "mx-4 flex size-6 shrink-0 items-center justify-center rounded-md border border-muted-foreground/15 bg-muted ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
             "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4"
           )}
         >

--- a/src/features/portfolio/components/blog.tsx
+++ b/src/features/portfolio/components/blog.tsx
@@ -49,7 +49,7 @@ export function Blog() {
         </ul>
       </div>
 
-      <div className="screen-line-top flex justify-center py-2">
+      <div className="screen-line-top flex justify-center py-4">
         <Button
           className="gap-2 pr-2.5 pl-3"
           variant="secondary"

--- a/src/features/portfolio/components/bookmarks/bookmark-item.tsx
+++ b/src/features/portfolio/components/bookmarks/bookmark-item.tsx
@@ -28,7 +28,7 @@ export function BookmarkItem({
       <div
         className={cn(
           "mx-4 flex size-6 shrink-0 items-center justify-center rounded-md select-none",
-          "border border-muted-foreground/15 ring-1 ring-line ring-offset-1 ring-offset-background",
+          "border border-muted-foreground/15 ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
           "bg-muted text-muted-foreground [&_svg]:size-4"
         )}
       >

--- a/src/features/portfolio/components/certifications/certification-item.tsx
+++ b/src/features/portfolio/components/certifications/certification-item.tsx
@@ -60,7 +60,7 @@ export function CertificationItem({
         <div
           className={cn(
             "mx-4 flex size-6 shrink-0 items-center justify-center rounded-md select-none",
-            "border border-muted-foreground/15 ring-1 ring-line ring-offset-1 ring-offset-background",
+            "border border-muted-foreground/15 ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
             "bg-muted text-muted-foreground [&_svg]:size-4"
           )}
         >

--- a/src/features/portfolio/components/components.tsx
+++ b/src/features/portfolio/components/components.tsx
@@ -69,7 +69,7 @@ export function Components() {
         <div className="screen-line-top h-4 before:-top-px" />
       </div>
 
-      <div className="screen-line-top flex justify-center py-2">
+      <div className="screen-line-top flex justify-center py-4">
         <Button
           className="gap-2 pr-2.5 pl-3"
           variant="secondary"

--- a/src/features/portfolio/components/education/education-item.tsx
+++ b/src/features/portfolio/components/education/education-item.tsx
@@ -41,7 +41,7 @@ export function EducationItem({ item }: { item: Education }) {
               className={cn(
                 "flex size-6 shrink-0 items-center justify-center rounded-md",
                 "bg-muted text-muted-foreground",
-                "border border-muted-foreground/15 ring-1 ring-line ring-offset-1 ring-offset-background",
+                "border border-muted-foreground/15 ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
                 "[&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
               )}
             >

--- a/src/features/portfolio/components/experiences/experience-position-item.tsx
+++ b/src/features/portfolio/components/experiences/experience-position-item.tsx
@@ -47,7 +47,7 @@ export function ExperiencePositionItem({
             className={cn(
               "flex size-6 shrink-0 items-center justify-center rounded-md",
               "bg-muted text-muted-foreground",
-              "border border-muted-foreground/15 ring-1 ring-line ring-offset-1 ring-offset-background",
+              "border border-muted-foreground/15 ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
               "[&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
             )}
           >

--- a/src/features/portfolio/components/experiences/index.tsx
+++ b/src/features/portfolio/components/experiences/index.tsx
@@ -40,7 +40,7 @@ export function Experiences() {
             <ExperienceList experiences={EXPERIENCES.slice(MAX)} />
           </CollapsibleContent>
 
-          <div className="-mt-px flex items-center justify-center py-2">
+          <div className="-mt-px flex items-center justify-center py-4">
             <CollapsibleTrigger
               render={
                 <Button

--- a/src/features/portfolio/components/overview/intro-item.tsx
+++ b/src/features/portfolio/components/overview/intro-item.tsx
@@ -19,7 +19,7 @@ export function IntroItemIcon({
   return (
     <div
       className={cn(
-        "flex size-6 shrink-0 items-center justify-center rounded-md border border-muted-foreground/15 bg-muted ring-1 ring-line ring-offset-1 ring-offset-background",
+        "flex size-6 shrink-0 items-center justify-center rounded-md border border-muted-foreground/15 bg-muted ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
         "[&_svg]:pointer-events-none [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
         className
       )}

--- a/src/features/portfolio/components/projects/project-item.tsx
+++ b/src/features/portfolio/components/projects/project-item.tsx
@@ -47,7 +47,7 @@ export function ProjectItem({
             aria-hidden
           />
         ) : (
-          <div className="mx-4 flex size-6 shrink-0 items-center justify-center rounded-lg border border-muted-foreground/15 bg-muted text-muted-foreground ring-1 ring-line ring-offset-1 ring-offset-background select-none">
+          <div className="mx-4 flex size-6 shrink-0 items-center justify-center rounded-md border border-muted-foreground/15 bg-muted text-muted-foreground ring-1 ring-border/50 ring-offset-1 ring-offset-background select-none dark:ring-line">
             <BoxIcon className="size-4" />
           </div>
         )}

--- a/src/features/portfolio/components/sponsors.tsx
+++ b/src/features/portfolio/components/sponsors.tsx
@@ -74,7 +74,7 @@ export function Sponsors() {
         </ul>
       </div>
 
-      <div className="screen-line-top flex justify-center py-2">
+      <div className="screen-line-top -mb-px flex justify-center py-4">
         <Button
           className="gap-2 pr-2.5 pl-3"
           variant="secondary"

--- a/src/features/portfolio/components/testimonials.tsx
+++ b/src/features/portfolio/components/testimonials.tsx
@@ -107,7 +107,7 @@ export function Testimonials() {
         />
       </PanelContent>
 
-      <div className="screen-line-top flex justify-center py-2">
+      <div className="screen-line-top flex justify-center py-4">
         <Button
           className="gap-2 pr-2.5 pl-3"
           variant="secondary"


### PR DESCRIPTION
Update ring styles to use ring-border/50 in light mode and ring-line in dark mode for better theme consistency across icon containers. Standardize vertical padding from py-2 to py-4 for collapsible triggers and section footers to improve visual rhythm. Change rounded-lg to rounded-md in project item for consistency with other icon containers.