### PR TITLE
docs(AGENTS.md): add local dev URL section to document the

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,7 @@ pnpm registry:build     # Build shadcn registry (Bun script + shadcn build)
 pnpm registry:validate  # Validate generated registry.json
 pnpm icons:build        # Build registry icons
 ```
+
+### Local dev URL
+
+A dev server is usually already running behind `https://ncdai.localhost` (see `allowedDevOrigins` in `next.config.ts` and `NEXT_PUBLIC_APP_URL` in `.env.local`). Use that origin to test pages and routes, never `http://localhost:3000` or a raw port. It also makes generated absolute URLs match what the code produces.

--- a/src/app/(llms)/blocks.md/route.ts
+++ b/src/app/(llms)/blocks.md/route.ts
@@ -1,0 +1,58 @@
+import { blockCategories, registryConfig } from "@/config/registry"
+import { SITE_INFO } from "@/config/site"
+import { compareBlocksByCreatedAtDesc } from "@/lib/blocks"
+import { blocks } from "@/registry/blocks/_registry"
+
+const categorySections = blockCategories
+  .map((category) => {
+    const items = blocks
+      .filter(
+        (block) =>
+          block.type === "registry:block" &&
+          block.categories?.includes(category.name)
+      )
+      .sort(compareBlocksByCreatedAtDesc)
+
+    return { category, items }
+  })
+  .filter(({ items }) => items.length > 0)
+
+const totalBlocks = categorySections.reduce(
+  (total, { items }) => total + items.length,
+  0
+)
+
+const content = `# Blocks
+
+> Beautifully designed, production-ready blocks for React, Next.js, Tailwind CSS, and shadcn/ui.
+
+Install a block with the shadcn CLI: \`npx shadcn@latest add ${registryConfig.namespace}/<name>\`.
+
+Each link below opens a live preview of the block. ${totalBlocks} blocks in total.
+
+${categorySections
+  .map(
+    ({ category, items }) => `## ${category.title} (${items.length})
+
+${category.description}
+
+${items
+  .map(
+    (item) =>
+      `- [${item.title ?? item.name}](${SITE_INFO.url}/blocks/${category.name}/${item.name}): ${item.description}`
+  )
+  .join("\n")}`
+  )
+  .join("\n\n")}
+`
+
+export const revalidate = false
+export const dynamic = "force-static"
+
+export async function GET() {
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/markdown;charset=utf-8",
+    },
+  })
+}

--- a/src/app/(llms)/components.md/route.ts
+++ b/src/app/(llms)/components.md/route.ts
@@ -1,0 +1,35 @@
+import { registryConfig } from "@/config/registry"
+import { SITE_INFO } from "@/config/site"
+import { getComponentDocs } from "@/features/doc/data/documents"
+
+const allComponents = getComponentDocs()
+  .slice()
+  .sort((a, b) =>
+    a.metadata.title.localeCompare(b.metadata.title, "en", {
+      sensitivity: "base",
+    })
+  )
+
+const content = `# Components
+
+> Pixel-perfect, uniquely crafted components for React, Next.js, Tailwind CSS, and shadcn/ui.
+
+Install a component with the shadcn CLI: \`npx shadcn@latest add ${registryConfig.namespace}/<name>\`.
+
+Each link below returns the full documentation as Markdown. Drop the \`.mdx\` extension for the web page.
+
+## All components (${allComponents.length})
+
+${allComponents.map((item) => `- [${item.metadata.title}](${SITE_INFO.url}/components/${item.slug}.mdx): ${item.metadata.description}`).join("\n")}
+`
+
+export const revalidate = false
+export const dynamic = "force-static"
+
+export async function GET() {
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/markdown;charset=utf-8",
+    },
+  })
+}

--- a/src/features/portfolio/data/bookmarks.tsx
+++ b/src/features/portfolio/data/bookmarks.tsx
@@ -180,6 +180,19 @@ export const BOOKMARKS: Bookmark[] = [
     title: "Copper",
     url: "https://shadcn.com/copper",
     author: "shadcn",
+    icon: (
+      // Designed by shadcn.
+      <svg viewBox="0 0 24 24" fill="none">
+        <path
+          fill="currentColor"
+          d="M20.041 4.824a10.125 10.125 0 1 0 0 14.352 2.11 2.11 0 1 0-2.976-2.99 5.906 5.906 0 1 1 0-8.372 2.11 2.11 0 1 0 2.976-2.99"
+        />
+        <path
+          fill="currentColor"
+          d="M18.807 10.453h-1.631a.844.844 0 0 0-.844.844v1.406c0 .466.378.844.844.844h1.631a.844.844 0 0 0 .844-.844v-1.406a.844.844 0 0 0-.844-.844"
+        />
+      </svg>
+    ),
     category: BookmarkCategory.SOFTWARE,
     bookmarkedAt: "2026-07-30",
   },


### PR DESCRIPTION
required use of https://ncdai.localhost instead of localhost:3000

feat(llms): add blocks.md route to generate markdown list of all blocks grouped by category with installation instructions

feat(llms): add components.md route to generate markdown list of all components with links to their documentation

feat(portfolio): add Copper icon SVG to bookmarks for visual consistency with other bookmark entries