### PR TITLE
feat(portfolio): add sponsors carousel component to homepage

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -23,6 +23,7 @@ import { ProfileHeader } from "@/features/portfolio/components/profile-header"
 import { Projects } from "@/features/portfolio/components/projects"
 import { SocialLinks } from "@/features/portfolio/components/social-links"
 import { Sponsors } from "@/features/portfolio/components/sponsors"
+import { SponsorsCarousel } from "@/features/portfolio/components/sponsors-carousel"
 import { TechStack } from "@/features/portfolio/components/tech-stack"
 import { Testimonials } from "@/features/portfolio/components/testimonials"
 import { USER } from "@/features/portfolio/data/user"
@@ -49,6 +50,7 @@ export default function HomePage() {
           <Separator />
 
           <Hello />
+          <SponsorsCarousel />
           <Separator />
 
           <Testimonials />

--- a/src/features/portfolio/components/sponsors-carousel.tsx
+++ b/src/features/portfolio/components/sponsors-carousel.tsx
@@ -1,0 +1,35 @@
+import { LogosCarousel } from "@/registry/components/logos-carousel"
+import { SPONSORS } from "@/features/sponsor/data"
+
+import { Panel } from "./panel"
+
+export function SponsorsCarousel() {
+  return (
+    <Panel className="@container py-4 screen-line-top-none">
+      <p className="mb-4 pl-4 text-sm font-medium tracking-wide text-muted-foreground">
+        Proudly supported by
+      </p>
+
+      <div className="relative">
+        <div
+          className="pointer-events-none absolute inset-0 grid grid-cols-2 items-center *:h-5 *:border-r @2xl:grid-cols-4"
+          aria-hidden
+        >
+          <div className="@max-2xl:h-full @max-2xl:border-line" />
+          <div className="@max-2xl:hidden" />
+          <div className="@max-2xl:hidden" />
+        </div>
+
+        <LogosCarousel className="w-full gap-y-4 [--column-count:2] @2xl:[--column-count:4]">
+          {SPONSORS.map((sponsor, index) => (
+            <sponsor.logo
+              key={index}
+              className="h-auto w-full @max-2xl:max-w-48"
+              aria-label={sponsor.name}
+            />
+          ))}
+        </LogosCarousel>
+      </div>
+    </Panel>
+  )
+}


### PR DESCRIPTION
Add new SponsorsCarousel component that displays sponsor logos in a responsive carousel layout with grid-based columns that adapt from 2 columns to 4 columns at larger breakpoints to showcase sponsors in a more engaging and space-efficient manner