### PR TITLE
feat(insights): show percentage change vs previous cycle

### DIFF
--- a/src/features/portfolio/components/insights.tsx
+++ b/src/features/portfolio/components/insights.tsx
@@ -1,5 +1,6 @@
 import { formatDuration } from "@/utils/format"
 import { format } from "date-fns"
+import { ArrowDownIcon, ArrowUpIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import Grid from "@/components/charts/grid"
@@ -45,28 +46,40 @@ export async function Insights() {
 
         <dl className="grid grid-cols-2 md:grid-cols-4">
           <Metric>
-            <MetricLabel>Unique visitors</MetricLabel>
+            <MetricLabel>
+              Unique visitors
+              <MetricChange value={data.changes.unique_visitors} />
+            </MetricLabel>
             <MetricValue>
               {data.summary.unique_visitors.toLocaleString()}
             </MetricValue>
           </Metric>
 
           <Metric>
-            <MetricLabel>Sessions</MetricLabel>
+            <MetricLabel>
+              Sessions
+              <MetricChange value={data.changes.total_sessions} />
+            </MetricLabel>
             <MetricValue>
               {data.summary.total_sessions.toLocaleString()}
             </MetricValue>
           </Metric>
 
           <Metric>
-            <MetricLabel>Views</MetricLabel>
+            <MetricLabel>
+              Views
+              <MetricChange value={data.changes.total_screen_views} />
+            </MetricLabel>
             <MetricValue>
               {data.summary.total_screen_views.toLocaleString()}
             </MetricValue>
           </Metric>
 
           <Metric>
-            <MetricLabel>Session duration</MetricLabel>
+            <MetricLabel>
+              Session duration
+              <MetricChange value={data.changes.avg_session_duration} />
+            </MetricLabel>
             <MetricValue>
               {formatDuration(data.summary.avg_session_duration)}
             </MetricValue>
@@ -122,7 +135,9 @@ function Metric({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="metric"
       className={cn(
-        "flex flex-col gap-2 p-4",
+        // `justify-between` keeps values aligned across a row when a label
+        // wraps to two lines in a narrow column.
+        "flex flex-col justify-between gap-2 p-4",
         "max-sm:nth-[2n+1]:screen-line-bottom sm:nth-[3n+1]:screen-line-bottom",
         className
       )}
@@ -135,9 +150,46 @@ function MetricLabel({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <dt
       data-slot="metric-label"
-      className={cn("text-sm leading-none text-muted-foreground", className)}
+      className={cn(
+        "flex items-start justify-between gap-2 text-sm/4 text-muted-foreground",
+        className
+      )}
       {...props}
     />
+  )
+}
+
+/**
+ * Every metric shown here is one where higher is better, so up maps to green.
+ * The arrow carries the direction too, so the meaning survives without color.
+ */
+function MetricChange({ value }: { value: number | null }) {
+  if (value === null) {
+    return null
+  }
+
+  const percent = Math.round(value * 10) / 10
+  const Icon = percent > 0 ? ArrowUpIcon : ArrowDownIcon
+
+  return (
+    <span
+      data-slot="metric-change"
+      className={cn(
+        "flex shrink-0 items-center text-xs/4 tabular-nums",
+        // Shades differ per color scheme so each clears 4.5:1 on its background.
+        percent > 0 && "text-green-700 dark:text-green-500",
+        percent < 0 && "text-red-700 dark:text-red-400"
+      )}
+    >
+      {percent !== 0 && (
+        <>
+          <Icon className="size-3" aria-hidden />
+          <span className="sr-only">{percent > 0 ? "Up by " : "Down by "}</span>
+        </>
+      )}
+      {Math.abs(percent).toFixed(1)}%
+      <span className="sr-only"> compared to the previous period</span>
+    </span>
   )
 }
 

--- a/src/features/portfolio/data/insights.ts
+++ b/src/features/portfolio/data/insights.ts
@@ -17,36 +17,129 @@ type InsightsSeriesItem = {
   total_sessions: number
 }
 
-type InsightsResponse = {
-  summary: InsightsSummary
-  series: InsightsSeriesItem[]
+type DateRange = {
   startDate: ISODateString
   endDate: ISODateString
 }
 
+type OverviewResponse = DateRange & {
+  summary: InsightsSummary
+  series: InsightsSeriesItem[]
+}
+
+const METRIC_KEYS = [
+  "unique_visitors",
+  "total_sessions",
+  "total_screen_views",
+  "avg_session_duration",
+] as const satisfies readonly (keyof InsightsSummary)[]
+
+/**
+ * `null` when the previous cycle is unavailable or was zero, since growth from
+ * zero has no meaningful percentage.
+ */
+type InsightsChanges = Record<(typeof METRIC_KEYS)[number], number | null>
+
+type InsightsResponse = OverviewResponse & {
+  previous: (DateRange & { summary: InsightsSummary }) | null
+  changes: InsightsChanges
+}
+
+async function fetchOverview(
+  range?: DateRange
+): Promise<OverviewResponse | null> {
+  try {
+    const url = new URL(
+      `https://api.openpanel.dev/insights/${process.env.OPENPANEL_PROJECT_ID}/overview`
+    )
+
+    if (range) {
+      url.searchParams.set("startDate", range.startDate)
+      url.searchParams.set("endDate", range.endDate)
+    }
+
+    const res = await fetch(url, {
+      headers: {
+        "openpanel-client-id": process.env.OPENPANEL_CLIENT_ID!,
+        "openpanel-client-secret": process.env.OPENPANEL_CLIENT_SECRET!,
+      },
+    })
+
+    if (!res.ok) {
+      return null
+    }
+
+    const data = (await res.json()) as OverviewResponse
+    return data
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The API treats a range as `[startDate, endDate)`, so the cycle immediately
+ * before it ends exactly where the current one starts.
+ */
+function getPreviousRange({ startDate, endDate }: DateRange): DateRange | null {
+  const start = Date.parse(startDate)
+  const end = Date.parse(endDate)
+
+  if (Number.isNaN(start) || Number.isNaN(end) || end <= start) {
+    return null
+  }
+
+  return {
+    startDate: toDateParam(start - (end - start)),
+    endDate: toDateParam(start),
+  }
+}
+
+function toDateParam(time: number): ISODateString {
+  return new Date(time).toISOString().slice(0, 10)
+}
+
+function getPercentChange(current: number, previous?: number): number | null {
+  if (previous === undefined || previous === 0) {
+    return null
+  }
+
+  return ((current - previous) / previous) * 100
+}
+
+function getChanges(
+  current: InsightsSummary,
+  previous: InsightsSummary | null
+): InsightsChanges {
+  return Object.fromEntries(
+    METRIC_KEYS.map((key) => [
+      key,
+      getPercentChange(current[key], previous?.[key]),
+    ])
+  ) as InsightsChanges
+}
+
 export const getInsights = unstable_cache(
   async (): Promise<InsightsResponse | null> => {
-    try {
-      const res = await fetch(
-        `https://api.openpanel.dev/insights/${process.env.OPENPANEL_PROJECT_ID}/overview`,
-        {
-          headers: {
-            "openpanel-client-id": process.env.OPENPANEL_CLIENT_ID!,
-            "openpanel-client-secret": process.env.OPENPANEL_CLIENT_SECRET!,
-          },
-        }
-      )
+    const current = await fetchOverview()
 
-      if (!res.ok) {
-        return null
-      }
-
-      const data = (await res.json()) as InsightsResponse
-      return data
-    } catch {
+    if (current === null) {
       return null
+    }
+
+    const previousRange = getPreviousRange(current)
+    const previousSummary = previousRange
+      ? ((await fetchOverview(previousRange))?.summary ?? null)
+      : null
+
+    return {
+      ...current,
+      previous:
+        previousRange && previousSummary
+          ? { ...previousRange, summary: previousSummary }
+          : null,
+      changes: getChanges(current.summary, previousSummary),
     }
   },
   ["openpanel-insights"],
-  { revalidate: 86400 } // Cache for 1 day (86400 seconds)
+  { revalidate: 86400 } // 1 day
 )


### PR DESCRIPTION
Fetch the cycle immediately preceding the current window and derive a percentage change for each summary metric, rendered to the right of its label with an arrow and color that clears 4.5:1 in both color schemes.