### PR TITLE
feat(github-contributions): add figure caption and rework graph footer

### DIFF
--- a/src/features/portfolio/components/github-contributions/graph.tsx
+++ b/src/features/portfolio/components/github-contributions/graph.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { use } from "react"
-import { format } from "date-fns"
+import { format, parseISO } from "date-fns"
 import { LoaderIcon } from "lucide-react"
 
 import {
@@ -18,6 +18,7 @@ import {
   ContributionGraphLegend,
   ContributionGraphTotalCount,
 } from "@/registry/components/contribution-graph"
+import { SOCIAL } from "@/features/portfolio/data/social-links"
 
 export function GitHubContributionGraph({
   contributions,
@@ -26,56 +27,78 @@ export function GitHubContributionGraph({
 }) {
   const data = use(contributions)
 
+  if (data.length === 0) {
+    return null
+  }
+
   return (
-    <ContributionGraph
-      className="mx-auto gap-4 py-4"
-      data={data}
-      blockSize={12}
-      blockMargin={2}
-      blockRadius={0}
-      aria-label="GitHub Contributions Graph"
-    >
-      <ContributionGraphCalendar
-        className="px-4 **:data-[slot=month-labels]:text-muted-foreground"
-        title="GitHub Contributions"
-        aria-hidden
+    <figure>
+      <ContributionGraph
+        className="mx-auto gap-4 py-4"
+        data={data}
+        blockSize={12}
+        blockMargin={2}
+        blockRadius={0}
+        aria-label="GitHub Contributions Graph"
       >
-        {({ activity, dayIndex, weekIndex }) => (
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <g>
-                  <ContributionGraphBlock
-                    activity={activity}
-                    dayIndex={dayIndex}
-                    weekIndex={weekIndex}
-                  />
-                </g>
-              }
-            />
-            <TooltipContent className="font-sans">
-              <p>
-                {activity.count} contribution{activity.count > 1 ? "s" : null}{" "}
-                on {format(new Date(activity.date), "dd.MM.yyyy")}
-              </p>
-            </TooltipContent>
-          </Tooltip>
-        )}
-      </ContributionGraphCalendar>
-
-      <ContributionGraphFooter className="gap-4 px-4 leading-none">
-        <ContributionGraphTotalCount>
-          {({ totalCount }) => (
-            <div className="text-muted-foreground">
-              {totalCount.toLocaleString("en")} contributions in the past 365
-              days.
-            </div>
+        <ContributionGraphCalendar
+          className="px-4 **:data-[slot=month-labels]:text-muted-foreground"
+          title="GitHub Contributions"
+          aria-hidden
+        >
+          {({ activity, dayIndex, weekIndex }) => (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <g>
+                    <ContributionGraphBlock
+                      activity={activity}
+                      dayIndex={dayIndex}
+                      weekIndex={weekIndex}
+                    />
+                  </g>
+                }
+              />
+              <TooltipContent className="font-sans">
+                <p>
+                  {activity.count} contribution{activity.count > 1 ? "s" : null}{" "}
+                  on {format(parseISO(activity.date), "dd.MM.yyyy")}
+                </p>
+              </TooltipContent>
+            </Tooltip>
           )}
-        </ContributionGraphTotalCount>
+        </ContributionGraphCalendar>
 
-        <ContributionGraphLegend aria-hidden />
-      </ContributionGraphFooter>
-    </ContributionGraph>
+        <ContributionGraphFooter className="gap-4 px-4 leading-none">
+          <ContributionGraphTotalCount>
+            {({ totalCount }) => (
+              <div className="whitespace-normal text-muted-foreground tabular-nums">
+                {totalCount.toLocaleString("en")} contributions{" "}
+                <span className="whitespace-nowrap">
+                  ({format(parseISO(data[0].date), "dd.MM.yyyy")} –{" "}
+                  {format(parseISO(data[data.length - 1].date), "dd.MM.yyyy")})
+                </span>
+              </div>
+            )}
+          </ContributionGraphTotalCount>
+
+          <ContributionGraphLegend aria-hidden />
+        </ContributionGraphFooter>
+      </ContributionGraph>
+
+      <figcaption className="screen-line-top px-4 py-3 text-center text-sm text-balance text-muted-foreground">
+        FIG_002. Daily contribution activity. Source:{" "}
+        <a
+          href={SOCIAL.github.href}
+          className="link-underline"
+          target="_blank"
+          rel="noopener"
+        >
+          GitHub
+        </a>
+        .
+      </figcaption>
+    </figure>
   )
 }
 

--- a/src/features/portfolio/components/insights.tsx
+++ b/src/features/portfolio/components/insights.tsx
@@ -123,7 +123,7 @@ export async function Insights() {
         )}
 
         <figcaption className="screen-line-top px-4 py-3 text-center text-sm text-balance text-muted-foreground">
-          FIG_002. Daily unique visitors and sessions. Source:{" "}
+          FIG_003. Daily unique visitors and sessions. Source:{" "}
           <a
             href="https://openpanel.dev"
             className="link-underline"


### PR DESCRIPTION
Renumber the Insights caption to FIG_003, since contributions appears earlier in reading order on the home page and takes FIG_002.

Pair the total count with the exact date window, since month labels carry no year, and drop the "past 365 days" claim that the week-padded API window does not match. Parse activity dates with parseISO so they do not shift a day for viewers behind UTC.