### PR TITLE
feat(handwritten-note): annotate home page with handwritten margin notes

### DIFF
--- a/src/features/portfolio/components/components.tsx
+++ b/src/features/portfolio/components/components.tsx
@@ -13,6 +13,7 @@ import {
 import { ComponentIcon } from "@/features/doc/components/component-icon"
 import { getComponentDocs } from "@/features/doc/data/documents"
 
+import { HandwrittenArrow, HandwrittenNote } from "./handwritten-note"
 import { Panel, PanelHeader, PanelTitle, PanelTitleSup } from "./panel"
 import { PanelTitleCopy } from "./panel-title-copy"
 
@@ -23,6 +24,14 @@ export function Components() {
 
   return (
     <Panel id={ID}>
+      <HandwrittenNote
+        className="top-4 left-full ml-1 hidden w-36 flex-col items-start xl:flex"
+        aria-hidden
+      >
+        <span className="-rotate-3">free, copy &amp; paste</span>
+        <HandwrittenArrow className="mt-2 -rotate-3" />
+      </HandwrittenNote>
+
       <PanelHeader>
         <PanelTitle>
           <a href={`#${ID}`}>Components</a>

--- a/src/features/portfolio/components/handwritten-note.tsx
+++ b/src/features/portfolio/components/handwritten-note.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils"
+
+function HandwrittenNote({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="handwritten-note"
+      className={cn(
+        "pointer-events-none absolute font-handwritten text-xl/none tracking-normal text-muted-foreground select-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+/** Points down-left. Rotate or mirror it to aim at the subject. */
+function HandwrittenArrow({
+  className,
+  ...props
+}: React.ComponentProps<"svg">) {
+  return (
+    <svg
+      className={cn(
+        "size-8 shrink-0 text-[color-mix(in_oklab,var(--muted-foreground)_50%,var(--background))]",
+        className
+      )}
+      viewBox="0 0 40 40"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <path d="M34 4c1 15-5 26-21 30" />
+      <path d="m21 36-8-2 7-7" />
+    </svg>
+  )
+}
+
+export { HandwrittenArrow, HandwrittenNote }

--- a/src/features/portfolio/components/profile-header.tsx
+++ b/src/features/portfolio/components/profile-header.tsx
@@ -4,6 +4,7 @@ import { USER } from "@/features/portfolio/data/user"
 import { AvatarLightsToggle } from "./avatar-lights-toggle"
 import { ChanhDaiMarkIsometric } from "./chanhdai-mark-isometric"
 import { FlipSentences } from "./flip-sentences"
+import { HandwrittenArrow, HandwrittenNote } from "./handwritten-note"
 import { PronounceMyName } from "./pronounce-my-name"
 import { VerifiedIcon } from "./verified-icon"
 
@@ -12,6 +13,21 @@ export function ProfileHeader() {
     <div className="screen-line-bottom grid grid-cols-[auto_1fr] grid-rows-[1fr_auto] overflow-y-clip border-x border-line">
       <figure className="relative col-span-2 p-2 sm:col-span-1 sm:col-start-2 sm:p-4">
         <ChanhDaiMarkIsometric />
+
+        {/* w-36 needs ~1088px before the gutter can hold it without clipping,
+            and the mark ignores coarse pointers, so nothing to annotate there. */}
+        <HandwrittenNote
+          className="bottom-20 left-full hidden w-36 flex-col items-start pointer-fine:xl:flex"
+          aria-hidden
+        >
+          <HandwrittenArrow className="-scale-y-100 -rotate-6" />
+          <span className="ml-1 -rotate-6">
+            follows your cursor
+            <span className="block" />
+            click for a sound
+          </span>
+        </HandwrittenNote>
+
         <figcaption className="pointer-events-none absolute right-2 bottom-2 font-mono text-xs leading-none text-zinc-400 select-none sm:right-4 dark:text-zinc-700">
           FIG_001
         </figcaption>

--- a/src/features/portfolio/components/sponsors-carousel.tsx
+++ b/src/features/portfolio/components/sponsors-carousel.tsx
@@ -1,6 +1,7 @@
 import { LogosCarousel } from "@/registry/components/logos-carousel"
 import { SPONSORS } from "@/features/sponsor/data"
 
+import { HandwrittenArrow, HandwrittenNote } from "./handwritten-note"
 import { Panel } from "./panel"
 
 export function SponsorsCarousel() {
@@ -14,6 +15,11 @@ export function SponsorsCarousel() {
         <div />
         <div className="@max-2xl:hidden" />
       </div>
+
+      <HandwrittenNote className="top-6 right-full mr-2 hidden w-20 flex-col items-end lg:flex">
+        <span className="-rotate-6">big thanks</span>
+        <HandwrittenArrow className="size-7 -scale-x-100 -rotate-6" />
+      </HandwrittenNote>
 
       <div className="flex justify-center">
         <p className="flex h-10 items-center bg-background px-2 text-center text-xs/none font-semibold tracking-wider text-muted-foreground uppercase">


### PR DESCRIPTION
Add HandwrittenNote and HandwrittenArrow primitives built on the existing font-handwritten (Caveat), then annotate three spots: the isometric mark, the sponsors row, and the Components panel.

Notes are decorative and aria-hidden, and sit absolutely in the outer gutter so they never take part in layout. Each one is gated on a viewport wide enough for the gutter to hold it, otherwise the overflow-x-clip on main cuts the text off. The header note also requires a fine pointer, since the mark it describes ignores coarse ones.