### PR TITLE
refactor: standardize figure caption formatting across portfolio

### DIFF
--- a/src/features/portfolio/components/github-contributions/graph.tsx
+++ b/src/features/portfolio/components/github-contributions/graph.tsx
@@ -72,8 +72,11 @@ export function GitHubContributionGraph({
         <ContributionGraphFooter className="px-4 text-sm">
           <ContributionGraphTotalCount>
             {({ totalCount }) => (
-              <figcaption className="text-pretty text-muted-foreground tabular-nums">
-                FIG_002. {totalCount.toLocaleString("en")} contributions,{" "}
+              <figcaption className="text-pretty tabular-nums">
+                <span className="mr-2 tracking-wide text-muted-foreground">
+                  Fig. 2.
+                </span>
+                {totalCount.toLocaleString("en")} contributions,{" "}
                 {format(parseISO(data[0].date), "dd.MM.yyyy")} –{" "}
                 {format(parseISO(data[data.length - 1].date), "dd.MM.yyyy")}.
                 Source:{" "}

--- a/src/features/portfolio/components/insights.tsx
+++ b/src/features/portfolio/components/insights.tsx
@@ -122,8 +122,11 @@ export async function Insights() {
           </div>
         )}
 
-        <figcaption className="screen-line-top px-4 py-3 text-center text-sm text-balance text-muted-foreground">
-          FIG_003. Daily unique visitors and sessions. Source:{" "}
+        <figcaption className="screen-line-top px-4 py-3 text-center text-sm text-balance">
+          <span className="mr-2 tracking-wide text-muted-foreground">
+            Fig. 3.
+          </span>
+          Daily unique visitors and sessions. Source:{" "}
           <a
             href="https://openpanel.dev"
             className="link-underline"

--- a/src/features/portfolio/components/profile-header.tsx
+++ b/src/features/portfolio/components/profile-header.tsx
@@ -28,8 +28,8 @@ export function ProfileHeader() {
           </span>
         </HandwrittenNote>
 
-        <figcaption className="pointer-events-none absolute right-2 bottom-2 font-mono text-xs leading-none text-zinc-400 select-none sm:right-4 dark:text-zinc-700">
-          FIG_001
+        <figcaption className="pointer-events-none absolute right-2 bottom-2 text-sm leading-none tracking-wide text-[color-mix(in_oklab,var(--muted-foreground)_60%,var(--background))] tabular-nums select-none sm:right-4 sm:bottom-4">
+          Fig. 1.
         </figcaption>
       </figure>
 


### PR DESCRIPTION
Change figure numbering from uppercase underscore format (FIG_001, FIG_002, FIG_003) to sentence case with period (Fig. 1., Fig. 2., Fig. 3.) for better readability and consistency with academic conventions. Extract figure numbers into separate spans with muted-foreground color and tracking-wide spacing to visually distinguish them from caption text.