### PR TITLE
refactor: move HandwrittenNote components after main content

### DIFF
--- a/src/features/portfolio/components/components.tsx
+++ b/src/features/portfolio/components/components.tsx
@@ -24,14 +24,6 @@ export function Components() {
 
   return (
     <Panel id={ID}>
-      <HandwrittenNote
-        className="top-4 left-full ml-1 hidden w-36 flex-col items-start xl:flex"
-        aria-hidden
-      >
-        <span className="-rotate-3">free, copy &amp; paste</span>
-        <HandwrittenArrow className="mt-2 -rotate-3" />
-      </HandwrittenNote>
-
       <PanelHeader>
         <PanelTitle>
           <a href={`#${ID}`}>Components</a>
@@ -39,6 +31,14 @@ export function Components() {
           <PanelTitleCopy id={ID} />
         </PanelTitle>
       </PanelHeader>
+
+      <HandwrittenNote
+        className="top-4 left-full ml-1 hidden w-36 flex-col items-start xl:flex"
+        aria-hidden
+      >
+        <span className="-rotate-3">free, copy &amp; paste</span>
+        <HandwrittenArrow className="mt-2 -rotate-3" />
+      </HandwrittenNote>
 
       <div className="relative pt-4">
         <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-1 max-sm:hidden sm:grid-cols-2 md:grid-cols-3">

--- a/src/features/portfolio/components/social-links.tsx
+++ b/src/features/portfolio/components/social-links.tsx
@@ -20,11 +20,6 @@ export function SocialLinks() {
     <Panel>
       <h2 className="sr-only">Social Links</h2>
 
-      <HandwrittenNote className="-top-4 right-full mr-2 hidden w-20 flex-col items-end lg:flex">
-        <span className="-rotate-6">say hi</span>
-        <HandwrittenArrow className="mt-1 size-7 -scale-x-100 -rotate-6" />
-      </HandwrittenNote>
-
       <PanelContent>
         <ul className="flex flex-wrap gap-2">
           {SOCIAL_LINKS.map((item) => (
@@ -58,6 +53,11 @@ export function SocialLinks() {
           ))}
         </ul>
       </PanelContent>
+
+      <HandwrittenNote className="-top-4 right-full mr-4 hidden w-20 flex-col items-end lg:flex">
+        <span className="-rotate-6">say hi</span>
+        <HandwrittenArrow className="size-7 translate-x-4 -scale-x-100 -rotate-6" />
+      </HandwrittenNote>
     </Panel>
   )
 }

--- a/src/features/portfolio/components/sponsors-carousel.tsx
+++ b/src/features/portfolio/components/sponsors-carousel.tsx
@@ -16,11 +16,6 @@ export function SponsorsCarousel() {
         <div className="@max-2xl:hidden" />
       </div>
 
-      <HandwrittenNote className="top-6 right-full mr-2 hidden w-20 flex-col items-end lg:flex">
-        <span className="-rotate-6">big thanks</span>
-        <HandwrittenArrow className="size-7 -scale-x-100 -rotate-6" />
-      </HandwrittenNote>
-
       <div className="flex justify-center">
         <p className="flex h-10 items-center bg-background px-2 text-center text-xs/none font-semibold tracking-wider text-muted-foreground uppercase">
           Proudly supported by
@@ -43,6 +38,11 @@ export function SponsorsCarousel() {
           <sponsor.logo key={sponsor.name} className="h-auto w-full" />
         ))}
       </LogosCarousel>
+
+      <HandwrittenNote className="top-6 right-full mr-2 hidden w-20 flex-col items-end lg:flex">
+        <span className="-rotate-6">big thanks</span>
+        <HandwrittenArrow className="size-7 -scale-x-100 -rotate-6" />
+      </HandwrittenNote>
     </Panel>
   )
 }


### PR DESCRIPTION
Move HandwrittenNote elements to appear after the primary content in Components, SocialLinks, and SponsorsCarousel components to improve DOM order and accessibility while maintaining visual positioning through CSS