### PR TITLE
feat(footer): rebuild footer as a technical drawing title block

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
 NEXT_PUBLIC_APP_URL=https://acme.com
 
+# Set by Vercel on every deployment and read by the footer title block.
+# Locally they are unset, so the BUILD field reads "unavailable" — fill them in
+# to preview how a deployment renders. VERCEL_ENV: production | preview
+VERCEL_ENV=
+VERCEL_GIT_COMMIT_SHA=
+
 NEXT_PUBLIC_REGISTRY_NAMESPACE=@acme
 NEXT_PUBLIC_REGISTRY_NAMESPACE_URL=https://acme.com/r/{name}.json
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Built on shadcn/ui. Registry types and their definition files:
 | `registry:lib`       | `src/registry/lib/_registry.ts`        |
 | `registry:style`     | `src/registry/styles/_registry.ts`     |
 
-**NEVER EDIT** auto-generated outputs of `pnpm registry:build`: `registry.json`, `src/registry/__index__.tsx`, `src/registry/transformed/`, `public/r/*.json`
+**NEVER EDIT** auto-generated outputs of `pnpm registry:build`: `registry.json`, `registry-stats.json`, `src/registry/__index__.tsx`, `src/registry/transformed/`, `public/r/*.json`
 
 ### Adding a new component
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -51,6 +51,14 @@ const legacyBlogComponentRedirects = LEGACY_BLOG_COMPONENT_SLUGS.map(
 )
 
 const nextConfig: NextConfig = {
+  /**
+   * Stamped once per build and inlined. Reading the clock at render time would
+   * instead report whenever a page was regenerated, which drifts on the ISR
+   * routes and disagrees with the fully static ones.
+   */
+  env: {
+    BUILD_TIMESTAMP: new Date().toISOString(),
+  },
   reactStrictMode: true,
   typedRoutes: true,
   transpilePackages: ["next-mdx-remote"],

--- a/registry-stats.json
+++ b/registry-stats.json
@@ -1,0 +1,10 @@
+{
+  "total": 62,
+  "countByType": {
+    "registry:lib": 1,
+    "registry:hook": 2,
+    "registry:component": 39,
+    "registry:block": 11,
+    "registry:style": 9
+  }
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,7 +1,7 @@
 import dynamic from "next/dynamic"
 
 import { SiteBottomNav } from "@/components/site-bottom-nav"
-import { SiteFooter } from "@/components/site-footer"
+import { SiteFooterCad } from "@/components/site-footer-cad"
 import { SiteHeader } from "@/components/site-header"
 
 const ScrollToTop = dynamic(() =>
@@ -16,7 +16,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     <div className="group/layout relative isolate">
       <SiteHeader />
       <main className="max-w-screen overflow-x-clip px-2">{children}</main>
-      <SiteFooter />
+      <SiteFooterCad />
       <div
         className="pointer-events-none fixed inset-x-0 bottom-0 z-50"
         aria-hidden

--- a/src/components/site-footer-cad.tsx
+++ b/src/components/site-footer-cad.tsx
@@ -1,0 +1,282 @@
+import { LICENSE, SOURCE_CODE_GITHUB_URL } from "@/config/site"
+import type { BuildInfo } from "@/lib/build-info"
+import { getBuildInfo, getStack } from "@/lib/build-info"
+import { cn } from "@/lib/utils"
+import { DmcaIcon, GitHubIcon, LinkedInIcon, XIcon } from "@/components/icons"
+import { SiteFooterInteractiveLogotype } from "@/components/site-footer-brand"
+import { SOCIAL } from "@/features/portfolio/data/social-links"
+
+// Imported here rather than through `@/config/site`, which client components
+// pull in, to keep the manifest out of client bundles.
+import packageJson from "../../package.json"
+// Precomputed by `pnpm registry:build`, so the count costs no registry import.
+import registryStats from "../../registry-stats.json"
+
+const INSPIRED_BY = [
+  "Tailwind CSS",
+  "shadcn/ui",
+  "Vercel",
+  "Evil Charts",
+  "Devouring Details",
+  "Skiper UI",
+  "Making Software",
+]
+
+const OPENPANEL_URL =
+  "https://openpanel.dev?utm_source=chanhdai.com&utm_medium=referral&utm_campaign=footer"
+
+// Not derived from `SITE_INFO.url`: that follows `NEXT_PUBLIC_APP_URL` and
+// would read `ncdai.localhost` in dev.
+const SITE_TITLE = "chanhdai.com"
+
+const SITE_SUBTITLE = packageJson.description
+
+/** Footer laid out as the title block of a technical drawing. */
+export function SiteFooterCad() {
+  const xLink = SOCIAL.x
+  const githubLink = SOCIAL.github
+  const linkedinLink = SOCIAL.linkedin
+
+  const build = getBuildInfo()
+  const stack = getStack()
+
+  return (
+    <footer className="max-w-screen overflow-x-clip px-2">
+      <div className="mx-auto border-x border-line group-has-data-[slot=layout-wide]/layout:container md:max-w-3xl">
+        <div className="screen-line-top screen-line-bottom">
+          <div className="stripe-divider h-12" />
+        </div>
+
+        <div className="relative">
+          <div className="screen-line-bottom flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 px-4 py-3 font-mono text-sm">
+            <span className="font-medium">{SITE_TITLE}</span>
+            <span className="font-sans text-muted-foreground">
+              {SITE_SUBTITLE}
+            </span>
+          </div>
+
+          <dl className="grid grid-cols-2 gap-px bg-line font-mono md:grid-cols-4">
+            <Field label="Crafted by">
+              <a
+                className="link-underline"
+                href={xLink.href}
+                target="_blank"
+                rel="noopener"
+              >
+                {xLink.handle}
+              </a>
+            </Field>
+
+            <Field label="Build">
+              <BuildValue build={build} />
+            </Field>
+
+            <Field label="Date">
+              <time dateTime={build.date}>{build.date}</time>
+            </Field>
+
+            <Field label="Registry">{registryStats.total} items</Field>
+
+            <Field label="Deployed on">Vercel</Field>
+
+            <Field label="Source code">
+              <a
+                className="link-underline"
+                href={SOURCE_CODE_GITHUB_URL}
+                target="_blank"
+                rel="noopener"
+              >
+                GitHub
+              </a>
+            </Field>
+
+            <Field label="License">
+              <a
+                className="link-underline"
+                href={LICENSE.url}
+                target="_blank"
+                rel="noopener"
+              >
+                {LICENSE.name}
+              </a>
+            </Field>
+
+            <Field label="Typeface">Geist</Field>
+
+            <Field className="col-span-2" label="Analytics">
+              <ul className="flex flex-col gap-0.5">
+                <li>
+                  <a
+                    className="link-underline"
+                    href={OPENPANEL_URL}
+                    target="_blank"
+                    rel="noopener"
+                  >
+                    OpenPanel
+                  </a>
+                </li>
+                <li>Google Analytics</li>
+              </ul>
+            </Field>
+
+            <Field className="col-span-2" label="Stack">
+              <ul className="flex flex-col gap-0.5">
+                {stack.map((entry) => (
+                  <li key={entry}>{entry}</li>
+                ))}
+              </ul>
+            </Field>
+
+            <Field className="col-span-2 md:col-span-4" label="Inspired by">
+              {/*
+                Cancelling the cell padding and repeating the parent's column
+                count and gap lands these columns on the same grid lines as the
+                cells above, rather than dividing the padded width.
+              */}
+              <ol className="-mx-4 grid grid-cols-2 gap-x-px gap-y-0.5 font-sans md:grid-cols-4">
+                {INSPIRED_BY.map((name, index) => (
+                  <li className="flex gap-2 px-4" key={name}>
+                    {/* Hidden: the list element already conveys the position. */}
+                    <span
+                      className="font-mono text-muted-foreground"
+                      aria-hidden
+                    >
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    {name}
+                  </li>
+                ))}
+              </ol>
+            </Field>
+          </dl>
+
+          <div
+            className="*:absolute *:z-2 *:size-2 *:border *:bg-background"
+            aria-hidden
+          >
+            <div className="top-[-4.5px] left-[-4.5px]" />
+            <div className="top-[-4.5px] right-[-4.5px]" />
+            <div className="bottom-[-4.5px] left-[-4.5px]" />
+            <div className="right-[-4.5px] bottom-[-4.5px]" />
+          </div>
+        </div>
+
+        <div className="screen-line-top screen-line-bottom flex w-full before:z-1 after:z-1">
+          <div className="mx-auto flex items-center justify-center gap-3 border-x border-line bg-background px-4">
+            <a
+              className="flex items-center text-muted-foreground transition-[color] hover:text-foreground"
+              href={xLink.href}
+              target="_blank"
+              rel="noopener"
+              aria-label="X Profile"
+            >
+              <XIcon className="size-4" />
+            </a>
+
+            <Separator />
+
+            <a
+              className="flex items-center text-muted-foreground transition-[color] hover:text-foreground"
+              href={githubLink.href}
+              target="_blank"
+              rel="noopener"
+              aria-label="GitHub Profile"
+            >
+              <GitHubIcon className="size-4" />
+            </a>
+
+            <Separator />
+
+            <a
+              className="flex items-center text-muted-foreground transition-[color] hover:text-foreground"
+              href={linkedinLink.href}
+              target="_blank"
+              rel="noopener"
+              aria-label="LinkedIn Profile"
+            >
+              <LinkedInIcon className="size-4" />
+            </a>
+
+            <Separator />
+
+            <a
+              className="flex text-muted-foreground transition-[color] hover:text-foreground"
+              href={
+                process.env.NEXT_PUBLIC_DMCA_URL ||
+                "https://www.dmca.com/ProtectionPro.aspx"
+              }
+              target="_blank"
+              rel="noopener"
+              aria-label="DMCA.com Protection Status"
+            >
+              <DmcaIcon className="h-4.5 w-auto" />
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <SiteFooterInteractiveLogotype />
+
+      <div className="h-(--fade-bottom-height)" />
+      <div className="pb-[env(safe-area-inset-bottom,0)]" />
+    </footer>
+  )
+}
+
+function BuildValue({ build }: { build: BuildInfo }) {
+  if (!build.commitShortSha) {
+    return <span className="text-muted-foreground">unavailable</span>
+  }
+
+  return (
+    <>
+      {build.commitUrl ? (
+        <a
+          className="link-underline"
+          href={build.commitUrl}
+          target="_blank"
+          rel="noopener"
+        >
+          {build.commitShortSha}
+        </a>
+      ) : (
+        build.commitShortSha
+      )}
+
+      {build.environment !== "production" && (
+        <span className="text-muted-foreground">
+          {" "}
+          ({build.environment === "development" ? "local" : build.environment})
+        </span>
+      )}
+    </>
+  )
+}
+
+function Field({
+  className,
+  label,
+  children,
+}: {
+  className?: string
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 flex-col gap-1 bg-background px-4 py-3",
+        className
+      )}
+    >
+      <dt className="text-[0.625rem]/4 font-medium tracking-wider text-muted-foreground uppercase">
+        {label}
+      </dt>
+      <dd className="text-sm">{children}</dd>
+    </div>
+  )
+}
+
+function Separator({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex h-11 w-px bg-line", className)} {...props} />
+}

--- a/src/lib/build-info.ts
+++ b/src/lib/build-info.ts
@@ -1,0 +1,75 @@
+import { SOURCE_CODE_GITHUB_URL } from "@/config/site"
+import { USER } from "@/features/portfolio/data/user"
+
+import packageJson from "../../package.json"
+
+/**
+ * Reads the Vercel deployment environment variables, which are server-side
+ * only — do not import this from a client component. Set them in `.env.local`
+ * to exercise the non-development rendering.
+ */
+
+const SHORT_SHA_LENGTH = 7
+
+export type BuildEnvironment = "production" | "preview" | "development"
+
+export type BuildInfo = {
+  commitShortSha: string | null
+  /** Null while running locally, where HEAD is often unpushed. */
+  commitUrl: string | null
+  environment: BuildEnvironment
+  /** YYYY-MM-DD, in the site owner's time zone. */
+  date: string
+}
+
+const dateFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: USER.timeZone,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+})
+
+/** Stamped by `next.config.ts` at build time. */
+const BUILD_DATE = dateFormatter.format(
+  process.env.BUILD_TIMESTAMP
+    ? new Date(process.env.BUILD_TIMESTAMP)
+    : new Date()
+)
+
+function resolveEnvironment(): BuildEnvironment {
+  const vercelEnv = process.env.VERCEL_ENV
+  return vercelEnv === "production" || vercelEnv === "preview"
+    ? vercelEnv
+    : "development"
+}
+
+export function getBuildInfo(): BuildInfo {
+  const environment = resolveEnvironment()
+  const commitSha = process.env.VERCEL_GIT_COMMIT_SHA
+
+  return {
+    commitShortSha: commitSha?.slice(0, SHORT_SHA_LENGTH) ?? null,
+    commitUrl:
+      commitSha && environment !== "development"
+        ? `${SOURCE_CODE_GITHUB_URL}/commit/${commitSha}`
+        : null,
+    environment,
+    date: BUILD_DATE,
+  }
+}
+
+const STACK_DEPENDENCIES = ["next", "react", "tailwindcss"]
+
+const declaredVersions: Record<string, string | undefined> = {
+  ...packageJson.dependencies,
+  ...packageJson.devDependencies,
+}
+
+/** The stack in npm spec form: `["next@16.3.0", …]`. */
+export function getStack(): string[] {
+  return STACK_DEPENDENCIES.flatMap((dependency) => {
+    // Drops the range prefix, so `^4.3.3` reads as a version.
+    const version = declaredVersions[dependency]?.replace(/^[^\d]*/, "")
+    return version ? [`${dependency}@${version}`] : []
+  })
+}

--- a/src/scripts/build-registry.mts
+++ b/src/scripts/build-registry.mts
@@ -20,6 +20,7 @@ import { getAllBlocks } from "@/lib/blocks"
  *
  * Persistent outputs:
  * - registry.json
+ * - registry-stats.json
  * - src/registry/__index__.tsx
  * - src/registry/transformed/components/*
  * - public/r/*
@@ -94,30 +95,32 @@ export const Index: Record<string, any> = {`
 }`
 
   // Build registry.json
+  const publishedItems = registry.items.filter(
+    (item) => item.type !== "registry:example"
+  )
+
   const registryJSON = JSON.stringify(
     {
       $schema: "https://ui.shadcn.com/schema/registry.json",
       name: "ncdai",
       homepage: "https://chanhdai.com/components",
-      items: registry.items
-        .filter((item) => item.type !== "registry:example")
-        .map((item) => {
-          return {
-            ...item,
-            author: item.author ?? "ncdai <dai@chanhdai.com>",
-            files:
-              item.files?.map((file) => {
-                if (file.path.startsWith("src/")) {
-                  return file
-                }
+      items: publishedItems.map((item) => {
+        return {
+          ...item,
+          author: item.author ?? "ncdai <dai@chanhdai.com>",
+          files:
+            item.files?.map((file) => {
+              if (file.path.startsWith("src/")) {
+                return file
+              }
 
-                return {
-                  ...file,
-                  path: `src/registry/${file.path}`,
-                }
-              }) ?? [],
-          }
-        }),
+              return {
+                ...file,
+                path: `src/registry/${file.path}`,
+              }
+            }) ?? [],
+        }
+      }),
     },
     null,
     2
@@ -129,6 +132,23 @@ export const Index: Record<string, any> = {`
   await fs.writeFile(
     path.join(process.cwd(), "registry.json"),
     registryJSON,
+    "utf8"
+  )
+
+  // Build registry-stats.json — the counts alone, so consumers that need only
+  // a number never import the whole registry.
+  console.log("\n📦 Building registry-stats.json...")
+  const countByType = publishedItems.reduce<Record<string, number>>(
+    (counts, item) => {
+      counts[item.type] = (counts[item.type] ?? 0) + 1
+      return counts
+    },
+    {}
+  )
+
+  await fs.writeFile(
+    path.join(process.cwd(), "registry-stats.json"),
+    `${JSON.stringify({ total: publishedItems.length, countByType }, null, 2)}\n`,
     "utf8"
   )
 


### PR DESCRIPTION
Replace the two-column definition list with a hairline grid of label/value cells, in the manner of a CAD title block. Adds provenance the footer never carried: commit SHA linked to its GitHub commit, build date, registry item count and stack versions.

Add src/lib/build-info.ts, which reads the Vercel deployment environment variables. VERCEL_ENV and VERCEL_GIT_COMMIT_SHA can be set in .env.local to preview how a deployment renders. The build date is stamped once in next.config.ts instead of read at render time, so it does not drift on the ISR routes.

Emit registry-stats.json from the registry build so the item count costs no registry import.

SiteFooter is left in place, now unused.