### PR TITLE
refactor(site-footer-cad): improve footer layout responsiveness

### DIFF
--- a/src/components/site-footer-cad.tsx
+++ b/src/components/site-footer-cad.tsx
@@ -160,10 +160,10 @@ export function SiteFooterCad() {
 
         <div className="screen-line-top h-4" />
 
-        <div className="screen-line-top screen-line-bottom flex flex-wrap items-center justify-between gap-x-4 gap-y-3 px-4 py-3 text-sm text-muted-foreground">
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+        <div className="screen-line-top screen-line-bottom flex flex-col items-center justify-center gap-x-4 gap-y-3 px-4 py-3 text-sm text-muted-foreground sm:flex-row sm:justify-between">
+          <div className="flex flex-col flex-wrap items-center gap-x-3 gap-y-1 sm:flex-row">
             <span>
-              © {build.date.slice(0, 4)} {COPYRIGHT_HOLDER}
+              © {build.date.slice(0, 4)} {COPYRIGHT_HOLDER}.
             </span>
 
             <a
@@ -189,7 +189,7 @@ export function SiteFooterCad() {
 
             <Separator
               orientation="vertical"
-              className="data-vertical:h-5 data-vertical:self-center"
+              className="data-vertical:h-4 data-vertical:self-center"
             />
 
             <a
@@ -204,7 +204,7 @@ export function SiteFooterCad() {
 
             <Separator
               orientation="vertical"
-              className="data-vertical:h-5 data-vertical:self-center"
+              className="data-vertical:h-4 data-vertical:self-center"
             />
 
             <a
@@ -219,7 +219,7 @@ export function SiteFooterCad() {
 
             <Separator
               orientation="vertical"
-              className="data-vertical:h-5 data-vertical:self-center"
+              className="data-vertical:h-4 data-vertical:self-center"
             />
 
             <a


### PR DESCRIPTION
Change footer layout from horizontal flex to vertical on mobile with centered alignment, switching to horizontal on larger screens to improve readability on small devices. Reduce separator height from h-5 to h-4 for better visual balance and add period after copyright holder for proper punctuation.