### PR TITLE
style: reduce opacity of muted foreground text elements

### DIFF
--- a/src/components/site-footer-cad.tsx
+++ b/src/components/site-footer-cad.tsx
@@ -145,7 +145,7 @@ export function SiteFooterCad() {
                   <li className="flex gap-2 px-4" key={name}>
                     {/* Hidden: the list element already conveys the position. */}
                     <span
-                      className="font-mono text-muted-foreground"
+                      className="font-mono text-muted-foreground/80"
                       aria-hidden
                     >
                       {String(index + 1).padStart(2, "0")}

--- a/src/features/portfolio/components/github-contributions/graph.tsx
+++ b/src/features/portfolio/components/github-contributions/graph.tsx
@@ -73,7 +73,7 @@ export function GitHubContributionGraph({
           <ContributionGraphTotalCount>
             {({ totalCount }) => (
               <figcaption className="text-pretty tabular-nums">
-                <span className="mr-2 tracking-wide text-muted-foreground">
+                <span className="mr-2 tracking-wide text-muted-foreground/80">
                   Fig. 2.
                 </span>
                 {totalCount.toLocaleString("en")} contributions,{" "}

--- a/src/features/portfolio/components/insights.tsx
+++ b/src/features/portfolio/components/insights.tsx
@@ -123,7 +123,7 @@ export async function Insights() {
         )}
 
         <figcaption className="screen-line-top px-4 py-3 text-center text-sm text-balance">
-          <span className="mr-2 tracking-wide text-muted-foreground">
+          <span className="mr-2 tracking-wide text-muted-foreground/80">
             Fig. 3.
           </span>
           Daily unique visitors and sessions. Source:{" "}

--- a/src/features/portfolio/components/tech-stack.tsx
+++ b/src/features/portfolio/components/tech-stack.tsx
@@ -33,12 +33,9 @@ export function TechStack() {
                 key={category}
                 className="grid items-start gap-y-2 border-b border-line py-4 last:border-none sm:grid-cols-[var(--col-left-width)_1fr]"
               >
-                <div
-                  id={categoryId}
-                  className="pl-4 text-sm/(--badge-height) text-muted-foreground"
-                >
+                <div id={categoryId} className="pl-4 text-sm/(--badge-height)">
                   <span
-                    className="mr-1.5 font-mono text-muted-foreground/50 select-none"
+                    className="mr-1.5 font-mono text-muted-foreground/80 select-none"
                     aria-hidden
                   >
                     {(index + 1).toString().padStart(2, "0")}


### PR DESCRIPTION
Apply 80% opacity to muted-foreground text across multiple components (figure captions, list numbers, category labels) to improve visual hierarchy and reduce visual noise while maintaining readability.