### PR TITLE
refactor: extract IconTile component to eliminate duplication

### DIFF
--- a/src/app/(app)/(pages)/components/component-item.tsx
+++ b/src/app/(app)/(pages)/components/component-item.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 
 import { cn } from "@/lib/utils"
+import { IconTile } from "@/components/ui/icon-tile"
 
 export function ComponentItem({
   className,
@@ -21,19 +22,9 @@ export function ComponentItem({
 export function ComponentItemIcon({
   className,
   ...props
-}: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="component-item-icon"
-      className={cn(
-        "relative flex size-6 shrink-0 items-center justify-center rounded-md",
-        "border border-muted-foreground/15 bg-muted ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
-        "[&_svg]:pointer-events-none [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
-        className
-      )}
-      {...props}
-    />
-  )
+}: React.ComponentProps<typeof IconTile>) {
+  // Positioned so ComponentItemDot can anchor to the tile corner.
+  return <IconTile className={cn("relative", className)} {...props} />
 }
 
 export function ComponentItemDot({

--- a/src/components/ui/icon-tile.tsx
+++ b/src/components/ui/icon-tile.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils"
+
+/**
+ * Small square chip that frames a leading icon in list items and metadata rows.
+ * The layered border + ring is a site-wide visual signature, so it lives here
+ * instead of being retyped per call site.
+ */
+export function IconTile({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="icon-tile"
+      className={cn(
+        "flex size-6 shrink-0 items-center justify-center rounded-md select-none",
+        "border border-muted-foreground/15 bg-muted text-muted-foreground",
+        "ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/features/portfolio/components/awards/award-item.tsx
+++ b/src/features/portfolio/components/awards/award-item.tsx
@@ -1,7 +1,7 @@
 import { format } from "date-fns"
 import { Crown, Paperclip } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { IconTile } from "@/components/ui/icon-tile"
 import {
   Collapsible,
   CollapsibleChevronsUpDownIcon,
@@ -31,14 +31,7 @@ export function AwardItem({
   return (
     <Collapsible className={className} disabled={!canExpand}>
       <div className="flex items-center hover:bg-accent-muted">
-        <div
-          className={cn(
-            "mx-4 flex size-6 shrink-0 items-center justify-center rounded-md border border-muted-foreground/15 bg-muted ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
-            "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4"
-          )}
-        >
-          {award.icon ?? <Crown />}
-        </div>
+        <IconTile className="mx-4">{award.icon ?? <Crown />}</IconTile>
 
         <div className="flex-1 border-l border-dashed border-line">
           <CollapsibleTrigger className="flex w-full items-center gap-2 p-4 pr-2 text-left">

--- a/src/features/portfolio/components/bookmarks/bookmark-item.tsx
+++ b/src/features/portfolio/components/bookmarks/bookmark-item.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRightIcon } from "lucide-react"
 
 import { UTM_PARAMS } from "@/config/site"
 import { cn } from "@/lib/utils"
+import { IconTile } from "@/components/ui/icon-tile"
 import { Separator } from "@/components/base/ui/separator"
 import { NewsIcon } from "@/components/icons"
 import {
@@ -25,15 +26,9 @@ export function BookmarkItem({
         className
       )}
     >
-      <div
-        className={cn(
-          "mx-4 flex size-6 shrink-0 items-center justify-center rounded-md select-none",
-          "border border-muted-foreground/15 ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
-          "bg-muted text-muted-foreground [&_svg]:size-4"
-        )}
-      >
+      <IconTile className="mx-4">
         {bookmark.icon ?? CATEGORY_ICONS[bookmark.category]}
-      </div>
+      </IconTile>
 
       <div className="flex-1 space-y-1 border-l border-dashed border-line p-4 pr-2">
         <h3 className="leading-snug font-medium text-balance">

--- a/src/features/portfolio/components/certifications/certification-item.tsx
+++ b/src/features/portfolio/components/certifications/certification-item.tsx
@@ -3,6 +3,7 @@ import { format } from "date-fns"
 import { ArrowUpRightIcon, CircleCheckBigIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { IconTile } from "@/components/ui/icon-tile"
 import { Separator } from "@/components/base/ui/separator"
 import {
   AccentureIcon,
@@ -57,17 +58,11 @@ export function CertificationItem({
           aria-hidden
         />
       ) : (
-        <div
-          className={cn(
-            "mx-4 flex size-6 shrink-0 items-center justify-center rounded-md select-none",
-            "border border-muted-foreground/15 ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
-            "bg-muted text-muted-foreground [&_svg]:size-4"
-          )}
-        >
+        <IconTile className="mx-4">
           {(certification.issuerIconName
             ? ISSUER_ICONS[certification.issuerIconName]
             : null) ?? <CircleCheckBigIcon />}
-        </div>
+        </IconTile>
       )}
 
       <div className="flex-1 space-y-1 border-l border-dashed border-line p-4 pr-2">

--- a/src/features/portfolio/components/education/education-item.tsx
+++ b/src/features/portfolio/components/education/education-item.tsx
@@ -1,6 +1,7 @@
 import { GraduationCapIcon, InfinityIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { IconTile } from "@/components/ui/icon-tile"
 import { Tag } from "@/components/ui/tag"
 import {
   Collapsible,
@@ -37,16 +38,9 @@ export function EducationItem({ item }: { item: Education }) {
           )}
         >
           <div className="relative z-1 mb-1 flex items-start gap-3 text-base">
-            <div
-              className={cn(
-                "flex size-6 shrink-0 items-center justify-center rounded-md",
-                "bg-muted text-muted-foreground",
-                "border border-muted-foreground/15 ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
-                "[&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
-              )}
-            >
+            <IconTile>
               <GraduationCapIcon />
-            </div>
+            </IconTile>
 
             <h3 className="flex-1 font-medium text-balance">{item.school}</h3>
 

--- a/src/features/portfolio/components/experiences/experience-position-item.tsx
+++ b/src/features/portfolio/components/experiences/experience-position-item.tsx
@@ -2,6 +2,7 @@ import { differenceInMonths, parse } from "date-fns"
 import { BriefcaseBusinessIcon, InfinityIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { IconTile } from "@/components/ui/icon-tile"
 import { Tag } from "@/components/ui/tag"
 import {
   Collapsible,
@@ -43,16 +44,7 @@ export function ExperiencePositionItem({
         )}
       >
         <div className="relative z-1 mb-1 flex items-start gap-3 text-base">
-          <div
-            className={cn(
-              "flex size-6 shrink-0 items-center justify-center rounded-md",
-              "bg-muted text-muted-foreground",
-              "border border-muted-foreground/15 ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
-              "[&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
-            )}
-          >
-            {position.icon ?? <BriefcaseBusinessIcon />}
-          </div>
+          <IconTile>{position.icon ?? <BriefcaseBusinessIcon />}</IconTile>
 
           <h4 className="flex-1 font-medium text-balance">{position.title}</h4>
 

--- a/src/features/portfolio/components/overview/intro-item.tsx
+++ b/src/features/portfolio/components/overview/intro-item.tsx
@@ -1,5 +1,8 @@
 import { cn } from "@/lib/utils"
 
+// Kept under the IntroItem* slot naming; the tile itself is shared site-wide.
+export { IconTile as IntroItemIcon } from "@/components/ui/icon-tile"
+
 export function IntroItem({
   className,
   ...props
@@ -7,22 +10,6 @@ export function IntroItem({
   return (
     <div
       className={cn("flex items-center gap-4 font-mono text-sm", className)}
-      {...props}
-    />
-  )
-}
-
-export function IntroItemIcon({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
-  return (
-    <div
-      className={cn(
-        "flex size-6 shrink-0 items-center justify-center rounded-md border border-muted-foreground/15 bg-muted ring-1 ring-border/50 ring-offset-1 ring-offset-background dark:ring-line",
-        "[&_svg]:pointer-events-none [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
-        className
-      )}
       {...props}
     />
   )

--- a/src/features/portfolio/components/projects/project-item.tsx
+++ b/src/features/portfolio/components/projects/project-item.tsx
@@ -3,6 +3,7 @@ import { addQueryParams } from "@/utils/url"
 import { BoxIcon, InfinityIcon, LinkIcon } from "lucide-react"
 
 import { UTM_PARAMS } from "@/config/site"
+import { IconTile } from "@/components/ui/icon-tile"
 import { Tag } from "@/components/ui/tag"
 import {
   Collapsible,
@@ -47,9 +48,9 @@ export function ProjectItem({
             aria-hidden
           />
         ) : (
-          <div className="mx-4 flex size-6 shrink-0 items-center justify-center rounded-md border border-muted-foreground/15 bg-muted text-muted-foreground ring-1 ring-border/50 ring-offset-1 ring-offset-background select-none dark:ring-line">
-            <BoxIcon className="size-4" />
-          </div>
+          <IconTile className="mx-4">
+            <BoxIcon />
+          </IconTile>
         )}
 
         <div className="flex-1 border-l border-dashed border-line">


### PR DESCRIPTION
Create shared IconTile component with consistent styling for icon containers used across portfolio items (awards, bookmarks, certifications, education, experiences, projects, and overview). This reduces code duplication and ensures visual consistency of the layered border + ring design pattern site-wide.