### PR TITLE
feat(blocks): add block mockups and list blocks on home and /blocks

### DIFF
--- a/src/app/(app)/(blocks)/blocks/(list)/[category]/page.tsx
+++ b/src/app/(app)/(blocks)/blocks/(list)/[category]/page.tsx
@@ -1,13 +1,12 @@
-import { Fragment } from "react"
 import type { Metadata } from "next"
 import type { CollectionPage, WithContext } from "schema-dts"
 
 import { blockCategories } from "@/config/registry"
 import { X_HANDLE } from "@/config/site"
-import { getAllBlockIds } from "@/lib/blocks"
 import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { absoluteUrl } from "@/lib/utils"
-import { BlockDisplay } from "@/app/(preview)/components/block-display"
+import { BlockList } from "@/features/blocks/components/block-list"
+import { getBlocks } from "@/features/blocks/data/blocks"
 
 export const revalidate = false
 export const dynamic = "force-static"
@@ -63,7 +62,7 @@ export async function generateMetadata({
 
 function getCollectionPageJsonLd(
   category: { name: string; title: string; description: string },
-  blockIds: string[]
+  blocks: ReturnType<typeof getBlocks>
 ): WithContext<CollectionPage> {
   const categoryUrl = `/blocks/${category.name}`
 
@@ -76,11 +75,11 @@ function getCollectionPageJsonLd(
     url: absoluteUrl(categoryUrl),
     mainEntity: {
       "@type": "ItemList",
-      numberOfItems: blockIds.length,
-      itemListElement: blockIds.map((blockId, index) => ({
+      numberOfItems: blocks.length,
+      itemListElement: blocks.map((block, index) => ({
         "@type": "ListItem",
         position: index + 1,
-        url: absoluteUrl(`/blocks/${category.name}/${blockId}`),
+        url: absoluteUrl(`/blocks/${category.name}/${block.name}`),
       })),
     },
     isPartOf: {
@@ -97,14 +96,14 @@ export default async function BlocksPage({
 }: PageProps<"/blocks/[category]">) {
   const { category } = await params
 
-  const blockIds = await getAllBlockIds(["registry:block"], [category])
+  const blocks = getBlocks(category)
 
   const categoryItem = blockCategories.find((item) => item.name === category)
 
   return (
     <>
       {categoryItem && (
-        <JsonLdScript data={getCollectionPageJsonLd(categoryItem, blockIds)} />
+        <JsonLdScript data={getCollectionPageJsonLd(categoryItem, blocks)} />
       )}
 
       <JsonLdScript
@@ -124,20 +123,7 @@ export default async function BlocksPage({
         ])}
       />
 
-      {blockIds.map((blockId) => (
-        <Fragment key={blockId}>
-          <BlockDisplay name={blockId} />
-          <Separator />
-        </Fragment>
-      ))}
+      <BlockList blocks={blocks} />
     </>
-  )
-}
-
-function Separator() {
-  return (
-    <div className="screen-line-top screen-line-bottom">
-      <div className="stripe-divider" />
-    </div>
   )
 }

--- a/src/app/(app)/(blocks)/blocks/(list)/layout.tsx
+++ b/src/app/(app)/(blocks)/blocks/(list)/layout.tsx
@@ -32,6 +32,8 @@ export default function BlocksLayout({
 
       {children}
 
+      <div className="screen-line-bottom h-px" />
+
       <div className="p-2">
         <div className="relative border border-line p-4">
           <p className="font-mono text-sm text-muted-foreground">

--- a/src/app/(app)/(blocks)/blocks/(list)/page.tsx
+++ b/src/app/(app)/(blocks)/blocks/(list)/page.tsx
@@ -1,4 +1,3 @@
-import { Fragment } from "react"
 import type { Metadata } from "next"
 import type { CollectionPage, WithContext } from "schema-dts"
 
@@ -6,8 +5,8 @@ import { JSON_LD_ID } from "@/config/json-ld"
 import { X_HANDLE } from "@/config/site"
 import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
 import { absoluteUrl } from "@/lib/utils"
-import blocks from "@/registry/__blocks__.json"
-import { BlockDisplay } from "@/app/(preview)/components/block-display"
+import { BlockList } from "@/features/blocks/components/block-list"
+import { getBlocks } from "@/features/blocks/data/blocks"
 
 export const dynamic = "force-static"
 export const revalidate = false
@@ -41,7 +40,9 @@ export const metadata: Metadata = {
   },
 }
 
-function getCollectionPageJsonLd(): WithContext<CollectionPage> {
+function getCollectionPageJsonLd(
+  blocks: ReturnType<typeof getBlocks>
+): WithContext<CollectionPage> {
   return {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
@@ -55,7 +56,7 @@ function getCollectionPageJsonLd(): WithContext<CollectionPage> {
       itemListElement: blocks.map((block, index) => ({
         "@type": "ListItem",
         position: index + 1,
-        url: absoluteUrl(`/blocks/${block.categories[0]}/${block.name}`),
+        url: absoluteUrl(`/blocks/${block.categories?.[0]}/${block.name}`),
       })),
     },
     isPartOf: { "@id": JSON_LD_ID.website },
@@ -63,9 +64,11 @@ function getCollectionPageJsonLd(): WithContext<CollectionPage> {
 }
 
 export default function BlocksPage() {
+  const blocks = getBlocks()
+
   return (
     <>
-      <JsonLdScript data={getCollectionPageJsonLd()} />
+      <JsonLdScript data={getCollectionPageJsonLd(blocks)} />
 
       <JsonLdScript
         data={jsonLdBreadcrumbList([
@@ -80,20 +83,7 @@ export default function BlocksPage() {
         ])}
       />
 
-      {blocks.map(({ name }) => (
-        <Fragment key={name}>
-          <BlockDisplay name={name} />
-          <Separator />
-        </Fragment>
-      ))}
+      <BlockList blocks={blocks} />
     </>
-  )
-}
-
-function Separator() {
-  return (
-    <div className="screen-line-top screen-line-bottom">
-      <div className="stripe-divider" />
-    </div>
   )
 }

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -6,6 +6,7 @@ import { JSON_LD_ID } from "@/config/json-ld"
 import { JsonLdScript } from "@/lib/json-ld"
 import { absoluteUrl, cn } from "@/lib/utils"
 import { Awards } from "@/features/portfolio/components/awards"
+import { Blocks } from "@/features/portfolio/components/blocks"
 import { Blog } from "@/features/portfolio/components/blog"
 import { Bookmarks } from "@/features/portfolio/components/bookmarks"
 import { Certifications } from "@/features/portfolio/components/certifications"
@@ -57,6 +58,9 @@ export default function HomePage() {
           <Separator />
 
           <Components />
+          <Separator />
+
+          <Blocks />
           <Separator />
 
           <Blog />

--- a/src/features/blocks/components/block-item.tsx
+++ b/src/features/blocks/components/block-item.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link"
+
+import type { Block } from "@/features/blocks/data/blocks"
+
+import { BLOCK_MOCKUPS } from "./mockups"
+import { MockupFrame } from "./mockups/mockup-frame"
+
+type HeadingTypes = "h2" | "h3" | "h4"
+
+export function BlockItem({
+  block,
+  headingAs,
+}: {
+  block: Block
+  headingAs?: HeadingTypes
+}) {
+  const Heading = headingAs ?? "h2"
+  const Mockup = BLOCK_MOCKUPS[block.name]
+  const category = block.categories?.[0]
+
+  return (
+    <div className="group/block relative flex h-full flex-col gap-2 p-2 transition-[background-color] ease-out hover:bg-accent-muted">
+      {Mockup && (
+        <div className="relative select-none [--image-radius:var(--radius-xl)]">
+          <MockupFrame className="rounded-(--image-radius)">
+            <Mockup />
+          </MockupFrame>
+          <div className="pointer-events-none absolute inset-0 rounded-(--image-radius) inset-ring-1 inset-ring-black/15 dark:inset-ring-white/15" />
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1 p-2">
+        <Heading className="text-lg leading-snug font-medium text-balance">
+          <Link href={`/blocks/${category}/${block.name}`}>
+            <span className="absolute inset-0" aria-hidden />
+            {block.title}
+          </Link>
+        </Heading>
+
+        {block.description && (
+          <p className="text-sm text-muted-foreground">{block.description}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/components/block-list.tsx
+++ b/src/features/blocks/components/block-list.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/lib/utils"
+import type { Block } from "@/features/blocks/data/blocks"
+
+import { BlockItem } from "./block-item"
+
+export function BlockList({ blocks }: { blocks: Block[] }) {
+  return (
+    <div className="relative py-4">
+      <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-1 gap-4 max-sm:hidden sm:grid-cols-2 lg:grid-cols-3">
+        <div className="border-r border-line" />
+        <div className="border-l border-line lg:border-r" />
+        <div className="border-l border-line max-lg:hidden" />
+      </div>
+
+      <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {blocks.map((block) => (
+          <li
+            key={block.name}
+            className={cn(
+              "max-sm:screen-line-top max-sm:screen-line-bottom",
+              "sm:max-lg:nth-[2n+1]:screen-line-top sm:max-lg:nth-[2n+1]:screen-line-bottom",
+              "lg:nth-[3n+1]:screen-line-top lg:nth-[3n+1]:screen-line-bottom"
+            )}
+          >
+            <BlockItem block={block} />
+          </li>
+        ))}
+
+        {blocks.length === 0 && (
+          <li className="screen-line-top screen-line-bottom p-4">
+            <p className="font-mono text-sm">No blocks found.</p>
+          </li>
+        )}
+      </ul>
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/blog-01.tsx
+++ b/src/features/blocks/components/mockups/blog-01.tsx
@@ -1,0 +1,25 @@
+import { Bar, Box, Button, Heading } from "./primitives"
+
+export function Blog01Mockup() {
+  return (
+    <div className="flex size-full flex-col gap-2 p-3">
+      <Heading className="h-2.5 w-10" />
+
+      <div className="grid flex-1 grid-cols-3 gap-1.5">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-1 rounded-sm bg-card p-1 shadow-xs ring-1 ring-foreground/10 dark:ring-border"
+          >
+            <Box className="aspect-2/1 w-full" />
+            <Bar className="h-0.75 w-1/2" />
+            <Bar className="w-full bg-muted-foreground/70" />
+            <Bar className="w-3/4 bg-muted-foreground/70" />
+          </div>
+        ))}
+      </div>
+
+      <Button className="mx-auto w-8" />
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/blog-02.tsx
+++ b/src/features/blocks/components/mockups/blog-02.tsx
@@ -1,0 +1,35 @@
+import { Bar, Box, Button, Heading } from "./primitives"
+
+export function Blog02Mockup() {
+  return (
+    <div className="flex size-full flex-col p-3">
+      <div className="flex flex-1 flex-col border-x border-line">
+        <div className="border-y border-line px-2 py-1.5">
+          <Heading className="h-2.5 w-10" />
+        </div>
+
+        <div className="border-b border-line px-2 py-1.5">
+          <Bar className="w-2/3" />
+        </div>
+
+        <div className="grid flex-1 grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex flex-col gap-0.75 border-line p-1 not-nth-[3n]:border-r nth-[-n+3]:border-b"
+            >
+              <Box className="aspect-5/2 w-full" />
+              <Bar className="w-full bg-muted-foreground/70" />
+              <Bar className="w-3/4 bg-muted-foreground/70" />
+              <Bar className="h-0.75 w-1/2" />
+            </div>
+          ))}
+        </div>
+
+        <div className="border-y border-line py-1.5">
+          <Button className="mx-auto w-8" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/experience-01.tsx
+++ b/src/features/blocks/components/mockups/experience-01.tsx
@@ -1,0 +1,80 @@
+import { Bar, Chip, Heading } from "./primitives"
+
+export function Experience01Mockup() {
+  return (
+    <div className="flex size-full flex-col p-3">
+      <div className="border-x border-line">
+        <div className="border-y border-line p-2">
+          <Heading className="h-2.5 w-1/3" />
+        </div>
+
+        <div className="border-b border-line p-2">
+          <Company />
+          <Position bullets={2} chips={5} isLast />
+        </div>
+
+        <div className="border-b border-line p-2">
+          <Company />
+          <Position bullets={0} chips={7} />
+          <Position bullets={0} chips={3} isLast />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Company() {
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="size-3 rounded-full bg-foreground" />
+      <Heading className="h-1.5 w-12" />
+      <div className="size-1.5 rounded-full bg-sky-500" />
+    </div>
+  )
+}
+
+function Position({
+  bullets,
+  chips,
+  isLast = false,
+}: {
+  bullets: number
+  chips: number
+  isLast?: boolean
+}) {
+  return (
+    <div className="mt-1.5 flex gap-1.5">
+      <div className="flex flex-col items-center gap-1">
+        <div className="size-3 shrink-0 rounded-xs border border-border bg-muted" />
+        {/* The connector only links to the next position, so the last one has none. */}
+        {!isLast && <div className="w-px flex-1 bg-line" />}
+      </div>
+
+      <div className="flex-1 space-y-1.5 pt-0.5 pb-1">
+        <Bar className="w-1/3 bg-muted-foreground/70" />
+        <div className="flex gap-1">
+          <Bar className="h-0.75 w-4" />
+          <Bar className="h-0.75 w-6" />
+          <Bar className="h-0.75 w-3" />
+        </div>
+
+        {bullets > 0 && (
+          <div className="space-y-1 pl-2">
+            {Array.from({ length: bullets }).map((_, i) => (
+              <div key={i} className="flex items-center gap-1">
+                <div className="size-0.75 rounded-full bg-muted-foreground/40" />
+                <Bar className="h-0.75 w-1/2" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="flex gap-1">
+          {Array.from({ length: chips }).map((_, i) => (
+            <Chip key={i} className="w-4" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/hero-01.tsx
+++ b/src/features/blocks/components/mockups/hero-01.tsx
@@ -1,0 +1,55 @@
+import { Bar, Button, Heading } from "./primitives"
+
+export function Hero01Mockup() {
+  return (
+    <div className="flex size-full flex-col p-3">
+      <div className="relative flex-1 overflow-hidden border border-line">
+        <GoldenSpiral className="absolute inset-0 size-full stroke-line" />
+
+        <div className="absolute top-1/2 left-[6%] w-[44%] -translate-y-1/2 space-y-3">
+          <Heading className="h-3.5 w-[85%]" />
+
+          <div className="space-y-1.5">
+            <Bar className="w-full" />
+            <Bar className="w-4/5" />
+          </div>
+
+          <div className="flex gap-1.5">
+            <Button className="w-12" />
+            <Button variant="outline" className="w-12" />
+          </div>
+
+          <div className="flex gap-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-1">
+                <div className="size-2 rounded-xs bg-muted-foreground/40" />
+                <Bar className="h-0.75 w-4" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function GoldenSpiral({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 340 210"
+      preserveAspectRatio="none"
+      className={className}
+      fill="none"
+      strokeWidth="2"
+    >
+      <path
+        d="M210 0v210M210 80.5h130M260 0v80.5M210 50.5h50M240 50.5v30M240 60.5h20"
+        vectorEffect="non-scaling-stroke"
+      />
+      <path
+        d="M239.897 60.3571C239.897 54.894 244.414 50.381 249.882 50.381C255.35 50.381 259.868 54.894 259.868 60.3571C259.868 71.2835 250.833 80.3095 239.897 80.3095C223.493 80.3095 209.941 66.7704 209.941 50.381C209.941 23.0652 232.527 0.499999 259.868 0.5C303.613 0.499995 339.75 36.6043 339.75 80.3095C339.75 151.33 281.027 210 209.941 210C95.1103 210 0.25 115.226 0.25 0.5"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  )
+}

--- a/src/features/blocks/components/mockups/index.ts
+++ b/src/features/blocks/components/mockups/index.ts
@@ -1,0 +1,27 @@
+import { Blog01Mockup } from "./blog-01"
+import { Blog02Mockup } from "./blog-02"
+import { Experience01Mockup } from "./experience-01"
+import { Hero01Mockup } from "./hero-01"
+import { Login01Mockup } from "./login-01"
+import { Metrics01Mockup } from "./metrics-01"
+import { NotFound01Mockup } from "./not-found-01"
+import { SocialLinks01Mockup } from "./social-links-01"
+import { SocialProof01Mockup } from "./social-proof-01"
+import { Team01Mockup } from "./team-01"
+import { Testimonials01Mockup } from "./testimonials-01"
+import { Testimonials02Mockup } from "./testimonials-02"
+
+export const BLOCK_MOCKUPS: Record<string, React.ComponentType> = {
+  "login-01": Login01Mockup,
+  "hero-01": Hero01Mockup,
+  "blog-01": Blog01Mockup,
+  "blog-02": Blog02Mockup,
+  "testimonials-01": Testimonials01Mockup,
+  "testimonials-02": Testimonials02Mockup,
+  "experience-01": Experience01Mockup,
+  "team-01": Team01Mockup,
+  "metrics-01": Metrics01Mockup,
+  "social-links-01": SocialLinks01Mockup,
+  "social-proof-01": SocialProof01Mockup,
+  "not-found-01": NotFound01Mockup,
+}

--- a/src/features/blocks/components/mockups/login-01.tsx
+++ b/src/features/blocks/components/mockups/login-01.tsx
@@ -1,0 +1,34 @@
+import { Bar, Button, Heading, Input } from "./primitives"
+
+export function Login01Mockup() {
+  return (
+    <div className="flex size-full items-center justify-center">
+      <div className="w-[30%] space-y-2 rounded-md border border-border bg-card p-2.5">
+        <div className="space-y-1.5">
+          <Heading className="h-1.5 w-1/2" />
+          <Bar className="w-3/4" />
+        </div>
+
+        <div className="space-y-1 pt-1">
+          <Bar className="w-1/6 bg-muted-foreground/70" />
+          <Input />
+        </div>
+
+        <div className="space-y-1">
+          <div className="flex justify-between">
+            <Bar className="w-1/5 bg-muted-foreground/70" />
+            <Bar className="w-1/3" />
+          </div>
+          <Input />
+        </div>
+
+        <div className="space-y-1 pt-1">
+          <Button className="w-full" />
+          <Button variant="outline" className="w-full" />
+        </div>
+
+        <Bar className="mx-auto w-1/2" />
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/metrics-01.tsx
+++ b/src/features/blocks/components/mockups/metrics-01.tsx
@@ -1,0 +1,63 @@
+import { cn } from "@/lib/utils"
+
+import { Bar, Heading } from "./primitives"
+
+const METRICS = [{ up: true }, { up: true }, { up: false }, { up: true }]
+
+export function Metrics01Mockup() {
+  return (
+    <div className="flex size-full flex-col justify-center px-3">
+      <div className="border-x border-line">
+        <div className="flex items-start gap-1 border-y border-line p-2">
+          <Heading className="h-2.5 w-12" />
+          <Bar className="h-0.75 w-6" />
+        </div>
+
+        <div className="grid grid-cols-4 border-b border-line">
+          {METRICS.map((metric, i) => (
+            <div
+              key={i}
+              className="space-y-1.5 border-line p-2 not-last:border-r"
+            >
+              <div className="flex items-center justify-between">
+                <Bar className="h-0.75 w-1/2" />
+                <Bar
+                  className={cn(
+                    "h-0.75 w-3",
+                    metric.up
+                      ? "bg-green-700 dark:bg-green-500"
+                      : "bg-red-700 dark:bg-red-400"
+                  )}
+                />
+              </div>
+              <Heading className="h-1.5 w-2/5" />
+            </div>
+          ))}
+        </div>
+
+        <div className="relative h-24 border-b border-line">
+          <div className="absolute inset-x-3 inset-y-2 flex flex-col justify-between">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="border-t border-dashed border-line" />
+            ))}
+          </div>
+
+          <svg
+            viewBox="0 0 100 40"
+            preserveAspectRatio="none"
+            className="absolute inset-x-3 inset-y-2 size-auto h-[calc(100%-1rem)] w-[calc(100%-1.5rem)]"
+            fill="none"
+          >
+            <path
+              d="M0 30C6 30 8 22 14 24S22 33 28 28 34 14 40 16 46 26 52 22 58 10 64 12 70 20 76 16 82 6 88 8 94 14 100 6"
+              className="stroke-(--chart-line-primary)"
+              strokeWidth="1.25"
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/mockup-frame.tsx
+++ b/src/features/blocks/components/mockups/mockup-frame.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils"
+
+// Mockups are drawn on a fixed 400x250 canvas and scaled to the frame width,
+// so their fixed px details keep the same proportions at every breakpoint.
+// tan(atan2(a, b)) is the CSS trick for dividing two lengths into a number.
+export function MockupFrame({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "@container aspect-16/10 overflow-hidden bg-background",
+        className
+      )}
+      {...props}
+    >
+      <div className="h-62.5 w-100 origin-top-left scale-[tan(atan2(100cqw,400px))]">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/not-found-01.tsx
+++ b/src/features/blocks/components/mockups/not-found-01.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils"
+
+import { Bar, Button, Heading } from "./primitives"
+
+const BRICKS = [".XX.XXX.", "X...X..X", "X...X..X", ".XX.XXX."]
+
+export function NotFound01Mockup() {
+  return (
+    <div className="flex size-full flex-col items-center gap-2 p-3">
+      <div className="flex flex-col items-center gap-1.5">
+        <div className="size-4 rounded-xs bg-muted" />
+        <Heading className="h-1.5 w-12" />
+        <div className="flex flex-col items-center gap-1">
+          <Bar className="h-0.75 w-20" />
+          <Bar className="h-0.75 w-14" />
+        </div>
+        <Button variant="outline" className="mt-0.5 w-12" />
+      </div>
+
+      <div className="relative w-[62%] flex-1 rounded-xs border border-border">
+        <div className="absolute inset-x-0 top-1.5 flex flex-col items-center gap-0.5">
+          {BRICKS.map((row, r) => (
+            <div key={r} className="flex gap-0.5">
+              {row.split("").map((cell, c) => (
+                <div
+                  key={c}
+                  className={cn(
+                    "h-3 w-3.5 rounded-[1px]",
+                    cell === "X" ? "bg-muted-foreground/50" : "bg-transparent"
+                  )}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <div className="absolute top-[62%] left-1/2 size-1.5 -translate-x-1/2 rounded-full bg-foreground/70" />
+        <div className="absolute bottom-1 left-1/2 h-1 w-7 -translate-x-1/2 rounded-[1px] bg-muted-foreground/70" />
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/primitives.tsx
+++ b/src/features/blocks/components/mockups/primitives.tsx
@@ -1,0 +1,101 @@
+import { cn } from "@/lib/utils"
+
+type DivProps = React.ComponentProps<"div">
+
+export function Bar({ className, ...props }: DivProps) {
+  return (
+    <div
+      className={cn("h-1 rounded-full bg-muted-foreground/40", className)}
+      {...props}
+    />
+  )
+}
+
+export function Heading({ className, ...props }: DivProps) {
+  return (
+    <div className={cn("h-2 rounded-xs bg-foreground", className)} {...props} />
+  )
+}
+
+export function Box({ className, ...props }: DivProps) {
+  return <div className={cn("rounded-xs bg-muted", className)} {...props} />
+}
+
+export function Avatar({ className, ...props }: DivProps) {
+  return (
+    <div
+      className={cn("rounded-full bg-muted-foreground/30", className)}
+      {...props}
+    />
+  )
+}
+
+export function Button({
+  variant = "primary",
+  className,
+  ...props
+}: DivProps & { variant?: "primary" | "outline" }) {
+  return (
+    <div
+      className={cn(
+        "h-3 w-10 rounded-xs",
+        variant === "primary"
+          ? "bg-foreground"
+          : "border border-border bg-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function Chip({ className, ...props }: DivProps) {
+  return (
+    <div
+      className={cn("h-1.5 w-5 rounded-xs bg-muted-foreground/20", className)}
+      {...props}
+    />
+  )
+}
+
+export function Input({ className, ...props }: DivProps) {
+  return (
+    <div
+      className={cn("h-3.5 rounded-xs border border-border", className)}
+      {...props}
+    />
+  )
+}
+
+export function MarqueeFade({
+  side,
+  className,
+  ...props
+}: DivProps & { side: "left" | "right" }) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute inset-y-0 w-10 from-background to-transparent",
+        side === "left" ? "left-0 bg-linear-to-r" : "right-0 bg-linear-to-l",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function ArrowUpRight({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 8 8"
+      className={cn("size-1.5 stroke-muted-foreground", className)}
+      fill="none"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2 6 6 2M3 2h3v3" />
+    </svg>
+  )
+}

--- a/src/features/blocks/components/mockups/social-links-01.tsx
+++ b/src/features/blocks/components/mockups/social-links-01.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils"
+
+import { ArrowUpRight, Bar } from "./primitives"
+
+const LABEL_WIDTHS = ["w-2", "w-6", "w-7", "w-7", "w-6", "w-7"]
+
+export function SocialLinks01Mockup() {
+  return (
+    <div className="flex size-full flex-col justify-center px-3">
+      <div className="grid grid-cols-3 border border-line">
+        {LABEL_WIDTHS.map((width, i) => (
+          <div
+            key={i}
+            className="relative flex items-center gap-1.5 border-line p-2 not-nth-[3n]:border-r nth-[-n+3]:border-b"
+          >
+            <div className="size-3.5 rounded-xs bg-foreground" />
+            <Bar className={cn("bg-muted-foreground/70", width)} />
+            <ArrowUpRight className="absolute top-1/2 right-2 -translate-y-1/2" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/social-proof-01.tsx
+++ b/src/features/blocks/components/mockups/social-proof-01.tsx
@@ -1,0 +1,66 @@
+import { cn } from "@/lib/utils"
+
+import { Bar } from "./primitives"
+
+const LOGOS = [
+  { mark: "triangle", word: "w-8" },
+  { mark: "circle", word: "w-9" },
+  { mark: "asterisk", word: "w-7" },
+  { mark: "pill", word: "w-9" },
+] as const
+
+export function SocialProof01Mockup() {
+  return (
+    <div className="flex size-full flex-col justify-center px-3">
+      <div className="border-x border-line">
+        <div className="flex justify-center border-y border-line py-1.5">
+          <Bar className="h-0.75 w-14" />
+        </div>
+
+        <div className="grid grid-cols-4 border-b border-line">
+          {LOGOS.map((logo, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-center gap-1 border-dashed border-line py-5 not-last:border-r"
+            >
+              <LogoMark kind={logo.mark} />
+              <Bar className={cn("h-2 rounded-xs bg-foreground", logo.word)} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function LogoMark({ kind }: { kind: (typeof LOGOS)[number]["mark"] }) {
+  switch (kind) {
+    case "triangle":
+      return (
+        <svg viewBox="0 0 10 10" className="size-2.5 fill-foreground">
+          <path d="M5 1 9.5 9H.5Z" />
+        </svg>
+      )
+    case "circle":
+      return <div className="size-2.5 rounded-full bg-foreground" />
+    case "asterisk":
+      return (
+        <svg
+          viewBox="0 0 10 10"
+          className="size-2.5 stroke-foreground"
+          strokeWidth="1.2"
+          strokeLinecap="round"
+        >
+          <path d="M5 1v8M1 5h8M2.2 2.2l5.6 5.6M7.8 2.2 2.2 7.8" />
+        </svg>
+      )
+    case "pill":
+      return (
+        <div className="flex items-end gap-px">
+          <div className="h-2.5 w-1.5 rounded-full bg-foreground" />
+          <div className="h-2.5 w-1 rounded-full bg-foreground" />
+          <div className="h-1.5 w-1 rounded-full bg-foreground" />
+        </div>
+      )
+  }
+}

--- a/src/features/blocks/components/mockups/team-01.tsx
+++ b/src/features/blocks/components/mockups/team-01.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils"
+
+import { Avatar, Bar } from "./primitives"
+
+export function Team01Mockup() {
+  return (
+    <div className="flex size-full items-center p-3">
+      <div className="grid w-full grid-cols-4 gap-1.5">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              "flex flex-col items-center gap-1.5 rounded-sm border border-border py-3",
+              // One card carries the glow so the hover effect is visible at a glance.
+              i === 1 &&
+                "border-foreground/30 shadow-[0_0_14px_-2px] shadow-foreground/25"
+            )}
+          >
+            <Avatar className="size-5" />
+            <div className="flex w-full flex-col items-center gap-1">
+              <Bar className="w-1/2 bg-muted-foreground/70" />
+              <Bar className="h-0.75 w-2/5" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/testimonials-01.tsx
+++ b/src/features/blocks/components/mockups/testimonials-01.tsx
@@ -1,0 +1,55 @@
+import { cn } from "@/lib/utils"
+
+import { Avatar, Bar, MarqueeFade } from "./primitives"
+
+// Cards are w-28 with gap-2. The first row hides half a card; the second
+// hides a whole one so its next card sits exactly one gap from the edge.
+const ROWS = [
+  { offset: "-ml-14", lines: [3, 2, 3, 2] },
+  { offset: "-ml-28", lines: [1, 2, 1, 1, 2] },
+]
+
+export function Testimonials01Mockup() {
+  return (
+    <div className="flex size-full flex-col justify-center">
+      <div className="relative space-y-2 overflow-hidden">
+        {ROWS.map((row, i) => (
+          <div key={i} className={cn("flex w-max gap-2", row.offset)}>
+            {row.lines.map((lines, j) => (
+              <TestimonialCard key={j} lines={lines} />
+            ))}
+          </div>
+        ))}
+
+        <MarqueeFade side="left" />
+        <MarqueeFade side="right" />
+      </div>
+    </div>
+  )
+}
+
+function TestimonialCard({ lines }: { lines: number }) {
+  return (
+    <div className="flex w-28 flex-col gap-2 rounded-sm border border-border bg-card p-2">
+      <div className="flex-1 space-y-1">
+        {Array.from({ length: lines }).map((_, i) => (
+          <Bar
+            key={i}
+            className={cn(
+              "bg-muted-foreground/70",
+              i === lines - 1 ? "w-3/5" : "w-full"
+            )}
+          />
+        ))}
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <Avatar className="size-3" />
+        <div className="flex-1 space-y-1">
+          <Bar className="h-0.75 w-1/2 bg-muted-foreground/70" />
+          <Bar className="h-0.75 w-3/4" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/components/mockups/testimonials-02.tsx
+++ b/src/features/blocks/components/mockups/testimonials-02.tsx
@@ -1,0 +1,67 @@
+import { cn } from "@/lib/utils"
+
+import { Avatar, Bar, Heading, MarqueeFade } from "./primitives"
+
+const ROWS = [
+  { offset: "-ml-[14%]", lines: [3, 2, 3, 2] },
+  { offset: "-ml-[30%]", lines: [1, 2, 1, 1, 2] },
+]
+
+export function Testimonials02Mockup() {
+  return (
+    <div className="flex size-full flex-col justify-center px-3">
+      <div className="border-x border-line">
+        <div className="border-y border-line p-2">
+          <Heading className="h-2 w-1/3" />
+        </div>
+        <div className="border-b border-line p-2">
+          <Bar className="w-1/2" />
+        </div>
+
+        {/* Fades live inside each row so the row borders stay unfaded,
+            mirroring how the real block wraps each marquee. */}
+        {ROWS.map((row, i) => (
+          <div
+            key={i}
+            className="relative overflow-hidden border-b border-line"
+          >
+            <div className={cn("flex w-max", row.offset)}>
+              {row.lines.map((lines, j) => (
+                <TestimonialCell key={j} lines={lines} />
+              ))}
+            </div>
+
+            <MarqueeFade side="left" />
+            <MarqueeFade side="right" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function TestimonialCell({ lines }: { lines: number }) {
+  return (
+    <div className="flex w-28 flex-col gap-2 border-r border-line p-2">
+      <div className="flex-1 space-y-1">
+        {Array.from({ length: lines }).map((_, i) => (
+          <Bar
+            key={i}
+            className={cn(
+              "bg-muted-foreground/70",
+              i === lines - 1 ? "w-3/5" : "w-full"
+            )}
+          />
+        ))}
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <Avatar className="size-3" />
+        <div className="flex-1 space-y-1">
+          <Bar className="h-0.75 w-1/2 bg-muted-foreground/70" />
+          <Bar className="h-0.75 w-3/4" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/blocks/data/blocks.ts
+++ b/src/features/blocks/data/blocks.ts
@@ -1,0 +1,14 @@
+import type { Registry } from "shadcn/schema"
+
+import { compareBlocksByCreatedAtDesc } from "@/lib/blocks"
+import { blocks } from "@/registry/blocks/_registry"
+
+export type Block = Registry["items"][number]
+
+// The registry source (not the generated index) is the only place that
+// carries block titles, so listings read from it directly.
+export function getBlocks(category?: string): Block[] {
+  return blocks
+    .filter((block) => !category || block.categories?.includes(category))
+    .sort(compareBlocksByCreatedAtDesc)
+}

--- a/src/features/portfolio/components/blocks/index.tsx
+++ b/src/features/portfolio/components/blocks/index.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link"
+import { ArrowRightIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/base/ui/button"
+import { BlockItem } from "@/features/blocks/components/block-item"
+import { getBlocks } from "@/features/blocks/data/blocks"
+
+import { Panel, PanelHeader, PanelTitle, PanelTitleSup } from "../panel"
+import { PanelTitleCopy } from "../panel-title-copy"
+
+const ID = "blocks"
+
+export function Blocks() {
+  const allBlocks = getBlocks()
+
+  return (
+    <Panel id={ID}>
+      <PanelHeader>
+        <PanelTitle>
+          <a href={`#${ID}`}>Blocks</a>
+          <PanelTitleSup>({allBlocks.length})</PanelTitleSup>
+          <PanelTitleCopy id={ID} />
+        </PanelTitle>
+      </PanelHeader>
+
+      <div className="relative py-4">
+        <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-1 gap-4 max-sm:hidden sm:grid-cols-2">
+          <div className="border-r border-line"></div>
+          <div className="border-l border-line"></div>
+        </div>
+
+        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {allBlocks.slice(0, 6).map((block) => (
+            <li
+              key={block.name}
+              className={cn(
+                "max-sm:screen-line-top max-sm:screen-line-bottom",
+                "sm:nth-[2n+1]:screen-line-top sm:nth-[2n+1]:screen-line-bottom"
+              )}
+            >
+              <BlockItem block={block} headingAs="h3" />
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="screen-line-top flex justify-center py-4">
+        <Button
+          className="gap-2 pr-2.5 pl-3 shadow-[inset_0_0_1px] shadow-foreground/20"
+          variant="secondary"
+          size="sm"
+          nativeButton={false}
+          render={<Link href="/blocks" />}
+        >
+          All blocks
+          <ArrowRightIcon />
+        </Button>
+      </div>
+    </Panel>
+  )
+}


### PR DESCRIPTION
Draw a JSX skeleton mockup for every block, scaled to its container with a fixed 400x250 canvas, and use it as the thumbnail in a new BlockItem/BlockList. Home gets a Blocks section after Components (same layout as Blog), and /blocks plus its category pages switch from full previews to a three-column grid of mockups.