### PR TITLE
refactor(portfolio): improve heading structure and expose sponsors ca…

### DIFF
--- a/src/features/blog/components/post-item.tsx
+++ b/src/features/blog/components/post-item.tsx
@@ -46,7 +46,7 @@ export function PostItem({
           {(post.metadata.new || post.metadata.updated) && (
             <span className="pointer-events-none ml-2 inline-block size-2 -translate-y-px rounded-full bg-info">
               <span className="sr-only">
-                {post.metadata.new ? "New" : "Updated"}
+                {post.metadata.new ? " (New)" : " (Updated)"}
               </span>
             </span>
           )}

--- a/src/features/doc/content/blog/react-wheel-picker-joins-vercel-open-source-program.mdx
+++ b/src/features/doc/content/blog/react-wheel-picker-joins-vercel-open-source-program.mdx
@@ -7,7 +7,7 @@ createdAt: 2025-07-24
 updatedAt: 2025-11-08
 ---
 
-I’m thrilled to share that [React Wheel Picker](https://react-wheel-picker.chanhdai.com) has been selected to join the [▲Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker) summer 2025 cohort.
+I’m thrilled to share that [React Wheel Picker](https://react-wheel-picker.chanhdai.com) has been selected to join the [▲ Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker) summer 2025 cohort.
 
 <FramedImage
   className="hidden [html.dark_&]:block"

--- a/src/features/doc/content/blog/two-of-my-projects-featured-on-orcdev-s-youtube-channel.mdx
+++ b/src/features/doc/content/blog/two-of-my-projects-featured-on-orcdev-s-youtube-channel.mdx
@@ -17,7 +17,7 @@ My Portfolio Website ([chanhdai.com](https://chanhdai.com)) was highlighted in "
 
 > Source: https://www.youtube.com/watch?v=-rdqQhw1_4M&t=313s
 
-[React Wheel Picker](https://react-wheel-picker.chanhdai.com) appeared in "**10 Tools to Make Your Shadcn Apps Beautiful**" — It’s an iOS-like wheel picker for React with smooth inertia scrolling and infinite loop support, proudly backed by the [▲Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker).
+[React Wheel Picker](https://react-wheel-picker.chanhdai.com) appeared in "**10 Tools to Make Your Shadcn Apps Beautiful**" — It’s an iOS-like wheel picker for React with smooth inertia scrolling and infinite loop support, proudly backed by the [▲ Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker).
 
 <YouTubeEmbed
   videoId="udfFLIx_ITc?start=272"

--- a/src/features/doc/content/components/react-wheel-picker.mdx
+++ b/src/features/doc/content/components/react-wheel-picker.mdx
@@ -22,7 +22,7 @@ updatedAt: 2026-02-08
 
 ## Features
 
-Built on top of [React Wheel Picker](https://react-wheel-picker.chanhdai.com) – Backed by ▲Vercel OSS Program.
+Built on top of [React Wheel Picker](https://react-wheel-picker.chanhdai.com) – Backed by ▲ Vercel OSS Program.
 
 - Natural touch scrolling with smooth inertia, mouse drag and scroll for desktop.
 - Infinite loop scrolling.

--- a/src/features/portfolio/components/github-contributions/index.tsx
+++ b/src/features/portfolio/components/github-contributions/index.tsx
@@ -10,7 +10,7 @@ export function GitHubContributions() {
 
   return (
     <Panel className="screen-line-top-none">
-      <h2 className="sr-only">GitHub Contributions</h2>
+      <h2 className="sr-only">GitHub contributions</h2>
 
       <Suspense fallback={<GitHubContributionFallback />}>
         <GitHubContributionGraph contributions={contributions} />

--- a/src/features/portfolio/components/hello-title.tsx
+++ b/src/features/portfolio/components/hello-title.tsx
@@ -9,8 +9,8 @@ const ID = "hello"
 const SSR_TEXT = "Hello"
 
 export function HelloTitle() {
-  // Server renders "Hello" for SEO; the client snapshot resolves the viewer's
-  // local greeting, which also covers client-side navigation (no inline script).
+  // Server renders "Hello"; the client snapshot resolves the viewer's local
+  // greeting, which also covers client-side navigation (no inline script).
   const greeting = useSyncExternalStore(
     () => () => {},
     getGreeting,
@@ -19,12 +19,10 @@ export function HelloTitle() {
 
   return (
     <>
-      <PanelTitle
-        id={`${ID}-greeting`}
-        className="font-handwritten leading-none"
-        suppressHydrationWarning
-      >
-        {greeting}
+      <PanelTitle asChild className="font-handwritten leading-none">
+        <div id={`${ID}-greeting`} aria-hidden suppressHydrationWarning>
+          {greeting}
+        </div>
       </PanelTitle>
 
       <InlineScript html={getInlineScript(`${ID}-greeting`)} />

--- a/src/features/portfolio/components/hello.tsx
+++ b/src/features/portfolio/components/hello.tsx
@@ -13,6 +13,7 @@ export function Hello() {
   return (
     <Panel id={ID} className="screen-line-bottom-none">
       <PanelHeader>
+        <h2 className="sr-only">About</h2>
         <HelloTitle />
       </PanelHeader>
 

--- a/src/features/portfolio/components/social-links.tsx
+++ b/src/features/portfolio/components/social-links.tsx
@@ -18,7 +18,7 @@ import { SOCIAL_LINKS } from "@/features/portfolio/data/social-links"
 export function SocialLinks() {
   return (
     <Panel>
-      <h2 className="sr-only">Social Links</h2>
+      <h2 className="sr-only">Social links</h2>
 
       <PanelContent>
         <ul className="flex flex-wrap gap-2">

--- a/src/features/portfolio/components/sponsors-carousel.tsx
+++ b/src/features/portfolio/components/sponsors-carousel.tsx
@@ -6,13 +6,7 @@ import { Panel } from "./panel"
 
 export function SponsorsCarousel() {
   return (
-    // Decorative. The full sponsor list with links lives in <Sponsors />, so
-    // this is hidden from assistive tech to avoid duplicating it. Keep it free
-    // of focusable content.
-    <Panel
-      className="@container screen-line-bottom-none screen-line-top-none"
-      aria-hidden
-    >
+    <Panel className="@container screen-line-bottom-none screen-line-top-none">
       <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-3 *:border-r *:border-dashed *:border-line @2xl:grid-cols-4">
         <div />
         <div />
@@ -20,29 +14,49 @@ export function SponsorsCarousel() {
       </div>
 
       <div className="flex justify-center">
-        <p className="flex h-10 items-center bg-background px-2 text-center text-sm/none font-medium text-muted-foreground">
-          Proudly supported by
-        </p>
+        <div className="bg-background px-2 py-4">
+          <h2 className="text-center text-sm/none font-medium text-muted-foreground">
+            Proudly supported by
+          </h2>
+        </div>
       </div>
 
       <div className="screen-line-bottom h-px" />
 
+      {/* Both visual renderings below are swapped per breakpoint via
+          display:none, which also drops them from the accessibility tree, so
+          assistive tech gets this one viewport-independent list of names
+          instead. The full linked list lives in <Sponsors />. */}
+      <ul className="sr-only">
+        {SPONSORS.map((sponsor) => (
+          <li key={sponsor.name}>{sponsor.name}</li>
+        ))}
+      </ul>
+
       {/* A full rotation runs past seven seconds, far longer than a phone
           spends scrolling by, so narrow viewports get every logo at once
           instead of a wave that only ever reveals a third of them. */}
-      <div className="grid grid-cols-3 py-2 text-muted-foreground @2xl:hidden">
+      <div
+        className="grid grid-cols-3 py-2 text-muted-foreground @2xl:hidden"
+        aria-hidden
+      >
         {SPONSORS.map((sponsor) => (
           <sponsor.logo key={sponsor.name} className="h-auto w-full" />
         ))}
       </div>
 
-      <LogosCarousel className="w-full py-4 text-muted-foreground [--column-count:4] @max-2xl:hidden">
-        {SPONSORS.map((sponsor) => (
-          <sponsor.logo key={sponsor.name} className="h-auto w-full" />
-        ))}
-      </LogosCarousel>
+      <div className="@max-2xl:hidden" aria-hidden>
+        <LogosCarousel className="w-full py-4 text-muted-foreground [--column-count:4]">
+          {SPONSORS.map((sponsor) => (
+            <sponsor.logo key={sponsor.name} className="h-auto w-full" />
+          ))}
+        </LogosCarousel>
+      </div>
 
-      <HandwrittenNote className="top-6 right-full mr-2 hidden w-20 flex-col items-end lg:flex">
+      <HandwrittenNote
+        className="top-6 right-full mr-2 hidden w-20 flex-col items-end lg:flex"
+        aria-hidden
+      >
         <span className="-rotate-6">big thanks</span>
         <HandwrittenArrow className="size-7 -scale-x-100 -rotate-6" />
       </HandwrittenNote>

--- a/src/features/portfolio/components/testimonials.tsx
+++ b/src/features/portfolio/components/testimonials.tsx
@@ -67,7 +67,7 @@ export function Testimonials() {
       <div className="h-4" />
       <div className="screen-line-bottom h-px" />
 
-      <div className="flex h-10 items-center justify-center">
+      <div className="flex items-center justify-center py-4">
         <h2 className="text-center text-sm/none font-medium text-muted-foreground">
           Trusted by top builders on{" "}
           <a href={SOCIAL.x.href} target="_blank" rel="noopener" aria-label="X">
@@ -92,7 +92,7 @@ export function Testimonials() {
         {TESTIMONIALS_FEATURED.map((item) => (
           <TestimonialSpotlight
             key={item.url}
-            className="bg-background inset-ring-foreground/20 [--spotlight-size:50%]"
+            className="bg-background inset-ring-foreground/15 [--spotlight-size:50%]"
           >
             <TestimonialItem {...item} showIcon />
           </TestimonialSpotlight>
@@ -154,7 +154,7 @@ function TestimonialsMarquee({
         {data.map((item) => (
           <MarqueeItem
             key={item.url}
-            className="mx-1 h-full w-xs rounded-xl bg-background inset-ring-1 inset-ring-border transition-[background-color] ease-out hover:bg-accent-muted"
+            className="mx-1 h-full w-xs rounded-xl bg-background inset-ring-1 inset-ring-foreground/15 transition-[background-color] ease-out hover:bg-accent-muted"
           >
             <TestimonialItem {...item} />
           </MarqueeItem>

--- a/src/features/portfolio/data/awards.tsx
+++ b/src/features/portfolio/data/awards.tsx
@@ -284,7 +284,7 @@ export const AWARDS: Award[] = [
     grade: "Open source project",
     icon: <VercelIcon />,
     description:
-      "- Selected for [▲Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker) summer 2025 cohort\n- Received $3,600 in platform credits, OSS Starter Pack, and priority community support\n- Project: [React Wheel Picker](https://react-wheel-picker.chanhdai.com)",
+      "- Selected for [▲ Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker) summer 2025 cohort\n- Received $3,600 in platform credits, OSS Starter Pack, and priority community support\n- Project: [React Wheel Picker](https://react-wheel-picker.chanhdai.com)",
     referenceLink:
       "https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker",
   },

--- a/src/features/portfolio/data/projects.tsx
+++ b/src/features/portfolio/data/projects.tsx
@@ -26,7 +26,7 @@ export const PROJECTS: Project[] = [
       "NPM Registry",
       "GitHub Actions",
     ],
-    description: `iOS-like wheel picker for React with smooth inertia scrolling and infinite loop support. / Backed by [▲Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker)
+    description: `iOS-like wheel picker for React with smooth inertia scrolling and infinite loop support. / Backed by [▲ Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker)
 - Natural touch scrolling with smooth inertia, mouse drag and scroll for desktop
 - Infinite loop scrolling
 - Unstyled core for complete style customization

--- a/src/features/portfolio/data/timeline.ts
+++ b/src/features/portfolio/data/timeline.ts
@@ -115,7 +115,7 @@ Won Bronze Medal — 10th Design, Manufacturing, and Application Award 2022.`,
   },
   {
     year: 2025,
-    content: `Open-sourced [chanhdai.com](https://github.com/ncdai/chanhdai.com) — 2k+ stars on GitHub.
+    content: `Open-sourced [chanhdai.com](https://github.com/ncdai/chanhdai.com) — 2.2k+ stars on GitHub.
 
 Released [React Wheel Picker](https://react-wheel-picker.chanhdai.com) — 50k+ weekly downloads, selected for the [Vercel OSS Program](https://vercel.com/open-source-program).
 

--- a/src/features/portfolio/data/user.ts
+++ b/src/features/portfolio/data/user.ts
@@ -35,7 +35,7 @@ export const USER: User = {
   ],
   about: `- I’m Chánh Đại (call me Dai) — a Design Engineer with 5+ years of experience, known for pixel-perfect execution and an obsessive attention to detail.
 - Passionate about exploring new technologies and turning ideas into reality through polished, thoughtfully crafted projects.
-- Creator of [chanhdai.com](https://github.com/ncdai/chanhdai.com) (2k stars), [React Wheel Picker](https://react-wheel-picker.chanhdai.com) (50k+ weekly downloads, ▲Vercel OSS Program), and [ZaDark](https://zadark.com) (80k+ downloads, 30k+ users) — peak metrics.
+- Creator of [chanhdai.com](https://github.com/ncdai/chanhdai.com) (2.2k stars), [React Wheel Picker](https://react-wheel-picker.chanhdai.com) (50k+ weekly downloads, ▲ Vercel OSS Program), and [ZaDark](https://zadark.com) (80k+ downloads, 30k+ users) — peak metrics.
 `,
   avatar: "https://assets.chanhdai.com/images/chanhdai-avatar-ghibli.webp",
   avatarVariants: {

--- a/src/registry/examples/timescale-demo.tsx
+++ b/src/registry/examples/timescale-demo.tsx
@@ -168,7 +168,7 @@ Won Bronze Medal — 10th Design, Manufacturing, and Application Award 2022.`,
   },
   {
     year: 2025,
-    content: `Open-sourced [chanhdai.com](https://github.com/ncdai/chanhdai.com) — 2k+ stars on GitHub.
+    content: `Open-sourced [chanhdai.com](https://github.com/ncdai/chanhdai.com) — 2.2k+ stars on GitHub.
 
 Released [React Wheel Picker](https://react-wheel-picker.chanhdai.com) — 50k+ weekly downloads, selected for the [Vercel OSS Program](https://vercel.com/open-source-program).
 


### PR DESCRIPTION
…rousel to assistive tech

- Unhide the sponsors carousel: add an sr-only sponsor name list, keep the viewport-dependent visuals and LogosCarousel aria-hidden
- Give the hello section an sr-only "About" heading and demote the time-based greeting to a decorative element
- Use sentence-case for sr-only headings (Social links, GitHub contributions)
- Announce blog post badges as "(New)"/"(Updated)" so they read as annotations instead of fusing into the post title
- Adjust testimonials heading spacing and unify card ring colors
- Update content: 2.2k GitHub stars, spacing in "▲ Vercel OSS Program"