### PR TITLE
refactor: replace clsx and tailwind-merge with cn package

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@visx/scale": "4.0.1-alpha.0",
     "@visx/shape": "4.0.1-alpha.0",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "cn": "^0.2.4",
     "d3-array": "^3.2.4",
@@ -100,7 +99,6 @@
     "schema-dts": "^1.1.5",
     "sharp": "^0.34.3",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.6.0",
     "vcard-creator": "^0.7.2",
     "web-haptics": "^0.0.6",
     "zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -177,9 +174,6 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      tailwind-merge:
-        specifier: ^3.6.0
-        version: 3.6.0
       vcard-creator:
         specifier: ^0.7.2
         version: 0.7.2
@@ -6623,9 +6617,6 @@ packages:
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
 
-  tailwind-merge@3.6.0:
-    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
-
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
@@ -11078,7 +11069,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.3.4(eslint@9.39.5(jiti@2.7.0))
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.6(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.8.6(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.6)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.4(eslint@9.39.5(jiti@2.7.0))
@@ -11105,7 +11096,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.8.6(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.8.6(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11120,14 +11111,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.6)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.6(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.6(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.8.6(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -11142,7 +11133,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.6)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.6(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14500,8 +14491,6 @@ snapshots:
   tagged-tag@1.0.0: {}
 
   tailwind-merge@3.3.1: {}
-
-  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.3: {}
 

--- a/src/features/doc/content/components/apple-hello-effect.mdx
+++ b/src/features/doc/content/components/apple-hello-effect.mdx
@@ -54,7 +54,7 @@ npx shadcn@latest add @ncdai/apple-hello-effect-vietnamese
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install motion clsx tailwind-merge
+npm install motion cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/brand-assets-menu.mdx
+++ b/src/features/doc/content/components/brand-assets-menu.mdx
@@ -38,7 +38,7 @@ npx shadcn@latest add @ncdai/brand-assets-menu
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge lucide-react
+npm install cn lucide-react
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/code-block-command.mdx
+++ b/src/features/doc/content/components/code-block-command.mdx
@@ -41,7 +41,7 @@ npx shadcn@latest add @ncdai/code-block-command
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge class-variance-authority lucide-react motion jotai radix-ui @base-ui/react
+npm install cn class-variance-authority lucide-react motion jotai radix-ui @base-ui/react
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/consent-manager.mdx
+++ b/src/features/doc/content/components/consent-manager.mdx
@@ -48,7 +48,7 @@ npx shadcn@latest add @ncdai/consent-manager
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge @c15t/nextjs
+npm install cn @c15t/nextjs
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/copy-button.mdx
+++ b/src/features/doc/content/components/copy-button.mdx
@@ -41,7 +41,7 @@ npx shadcn@latest add @ncdai/copy-button
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge class-variance-authority lucide-react motion radix-ui
+npm install cn class-variance-authority lucide-react motion radix-ui
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/elastic-slider.mdx
+++ b/src/features/doc/content/components/elastic-slider.mdx
@@ -55,7 +55,7 @@ npx shadcn@latest add @ncdai/elastic-slider
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install motion clsx tailwind-merge
+npm install motion cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/glow-card-grid.mdx
+++ b/src/features/doc/content/components/glow-card-grid.mdx
@@ -33,7 +33,7 @@ npx shadcn@latest add @ncdai/glow-card-grid
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge
+npm install cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/line-nav.mdx
+++ b/src/features/doc/content/components/line-nav.mdx
@@ -51,7 +51,7 @@ npx shadcn@latest add @ncdai/line-nav
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install motion clsx tailwind-merge
+npm install motion cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/logos-carousel.mdx
+++ b/src/features/doc/content/components/logos-carousel.mdx
@@ -32,7 +32,7 @@ npx shadcn@latest add @ncdai/logos-carousel
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install motion clsx tailwind-merge
+npm install motion cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/middle-truncation.mdx
+++ b/src/features/doc/content/components/middle-truncation.mdx
@@ -38,7 +38,7 @@ npx shadcn@latest add @ncdai/middle-truncation
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge
+npm install cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/react-wheel-picker.mdx
+++ b/src/features/doc/content/components/react-wheel-picker.mdx
@@ -50,7 +50,7 @@ npx shadcn@latest add @ncdai/wheel-picker
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install @ncdai/react-wheel-picker clsx tailwind-merge
+npm install @ncdai/react-wheel-picker cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/scroll-fade-effect.mdx
+++ b/src/features/doc/content/components/scroll-fade-effect.mdx
@@ -46,7 +46,7 @@ npx shadcn@latest add @ncdai/scroll-fade-effect
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge
+npm install cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/share-menu.mdx
+++ b/src/features/doc/content/components/share-menu.mdx
@@ -39,7 +39,7 @@ npx shadcn@latest add @ncdai/share-menu
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge lucide-react
+npm install cn lucide-react
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/shimmering-text.mdx
+++ b/src/features/doc/content/components/shimmering-text.mdx
@@ -48,7 +48,7 @@ npx shadcn@latest add @ncdai/shimmering-text
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install motion clsx tailwind-merge
+npm install motion cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/slide-to-unlock.mdx
+++ b/src/features/doc/content/components/slide-to-unlock.mdx
@@ -55,7 +55,7 @@ npx shadcn@latest add @ncdai/slide-to-unlock
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install motion clsx tailwind-merge
+npm install motion cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/status-button.mdx
+++ b/src/features/doc/content/components/status-button.mdx
@@ -40,7 +40,7 @@ npx shadcn@latest add @ncdai/status-button
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge class-variance-authority lucide-react motion radix-ui
+npm install cn class-variance-authority lucide-react motion radix-ui
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/testimonial-2.mdx
+++ b/src/features/doc/content/components/testimonial-2.mdx
@@ -32,7 +32,7 @@ npx shadcn@latest add @ncdai/testimonial-2
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge
+npm install cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/testimonial-spotlight.mdx
+++ b/src/features/doc/content/components/testimonial-spotlight.mdx
@@ -29,7 +29,7 @@ npx shadcn@latest add @ncdai/testimonial-spotlight
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge
+npm install cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/testimonial.mdx
+++ b/src/features/doc/content/components/testimonial.mdx
@@ -32,7 +32,7 @@ npx shadcn@latest add @ncdai/testimonial
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge
+npm install cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/testimonials-marquee.mdx
+++ b/src/features/doc/content/components/testimonials-marquee.mdx
@@ -39,7 +39,7 @@ npx shadcn@latest add @ncdai/testimonials-marquee
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge react-fast-marquee
+npm install cn react-fast-marquee
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/text-flip.mdx
+++ b/src/features/doc/content/components/text-flip.mdx
@@ -32,7 +32,7 @@ npx shadcn@latest add @ncdai/text-flip
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install motion clsx tailwind-merge
+npm install motion cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/theme-switcher.mdx
+++ b/src/features/doc/content/components/theme-switcher.mdx
@@ -32,7 +32,7 @@ npx shadcn@latest add @ncdai/theme-switcher
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install next-themes lucide-react motion clsx tailwind-merge
+npm install next-themes lucide-react motion cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/timescale.mdx
+++ b/src/features/doc/content/components/timescale.mdx
@@ -34,7 +34,7 @@ npx shadcn@latest add @ncdai/timescale
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge
+npm install cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/toc-minimap.mdx
+++ b/src/features/doc/content/components/toc-minimap.mdx
@@ -40,7 +40,7 @@ npx shadcn@latest add @ncdai/toc-minimap
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge
+npm install cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/twemoji.mdx
+++ b/src/features/doc/content/components/twemoji.mdx
@@ -38,7 +38,7 @@ npx shadcn@latest add @ncdai/twemoji
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge
+npm install cn
 ```
 
 <Step>Add a cn helper</Step>

--- a/src/features/doc/content/components/work-experience-component.mdx
+++ b/src/features/doc/content/components/work-experience-component.mdx
@@ -40,7 +40,7 @@ npx shadcn@latest add @ncdai/work-experience
 <Step>Install the following dependencies</Step>
 
 ```bash
-npm install clsx tailwind-merge react-markdown lucide-react motion
+npm install cn react-markdown lucide-react motion
 ```
 
 ```bash

--- a/src/registry/lib/utils.ts
+++ b/src/registry/lib/utils.ts
@@ -1,7 +1,1 @@
-import type { ClassValue } from "clsx"
-import { clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export const cn = (...inputs: ClassValue[]) => {
-  return twMerge(clsx(inputs))
-}
+export { cn } from "cn"


### PR DESCRIPTION
Remove clsx and tailwind-merge dependencies in favor of the cn package which provides the same functionality. Update all documentation files to reflect the new installation instructions and simplify the utils implementation by importing cn directly from the package instead of implementing it locally.