### PR TITLE
feat(ads): show the Carbon Ads unit in the components and blocks lists

### DIFF
--- a/src/app/(app)/(blocks)/blocks/(list)/[category]/page.tsx
+++ b/src/app/(app)/(blocks)/blocks/(list)/[category]/page.tsx
@@ -123,7 +123,7 @@ export default async function BlocksPage({
         ])}
       />
 
-      <BlockList blocks={blocks} />
+      <BlockList blocks={blocks} showAds />
     </>
   )
 }

--- a/src/app/(app)/(blocks)/blocks/(list)/page.tsx
+++ b/src/app/(app)/(blocks)/blocks/(list)/page.tsx
@@ -83,7 +83,7 @@ export default function BlocksPage() {
         ])}
       />
 
-      <BlockList blocks={blocks} />
+      <BlockList blocks={blocks} showAds />
     </>
   )
 }

--- a/src/app/(app)/(pages)/components/page.tsx
+++ b/src/app/(app)/(pages)/components/page.tsx
@@ -4,17 +4,19 @@ import { addQueryParams } from "@/utils/url"
 import { Grip, LayoutDashboard } from "lucide-react"
 import type { CollectionPage, WithContext } from "schema-dts"
 
+import { CARBON_ADS } from "@/config/ads"
 import { JSON_LD_ID } from "@/config/json-ld"
 import { registryConfig } from "@/config/registry"
 import { UTM_PARAMS, X_HANDLE } from "@/config/site"
 import { jsonLdBreadcrumbList, JsonLdScript } from "@/lib/json-ld"
-import { absoluteUrl, cn } from "@/lib/utils"
+import { absoluteUrl } from "@/lib/utils"
 import { Button } from "@/components/base/ui/button"
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/base/ui/tooltip"
+import { CarbonAds } from "@/components/carbon-ads"
 import { TrustedRegistryIcon } from "@/components/icons"
 import {
   PageHeading,
@@ -98,7 +100,7 @@ export default function Page() {
       })
     )
 
-  const newComponents = allComponents.filter((c) => c.metadata.new)
+  // const newComponents = allComponents.filter((c) => c.metadata.new)
 
   const trustedRegistryUrl = addQueryParams(
     "https://ui.shadcn.com/docs/directory",
@@ -150,15 +152,15 @@ export default function Page() {
 
         <div className="relative">
           <HandwrittenNote
-            className="top-1 left-full ml-1 hidden w-36 flex-col items-start lg:flex"
+            className="top-2 right-full mr-2 hidden w-36 flex-col items-end lg:flex"
             aria-hidden
           >
-            <span className="-rotate-3">free, copy &amp; paste</span>
-            <HandwrittenArrow className="mt-2 -rotate-3" />
+            <span className="-rotate-6">free, copy &amp; paste</span>
+            <HandwrittenArrow className="-scale-x-100 -rotate-6" />
           </HandwrittenNote>
         </div>
 
-        {newComponents.length > 0 && (
+        {/* {newComponents.length > 0 && (
           <>
             <div className="flex h-10 items-center pl-4">
               <h2 className="text-sm font-medium text-muted-foreground">
@@ -174,7 +176,7 @@ export default function Page() {
               <div className="stripe-divider" />
             </div>
           </>
-        )}
+        )} */}
 
         <div className="flex items-center gap-1.5 p-1.5 pl-4">
           <h2 className="flex-1 text-sm font-medium text-muted-foreground">
@@ -222,7 +224,7 @@ export default function Page() {
 
         <div className="screen-line-bottom h-px" />
 
-        <ComponentList items={allComponents} />
+        <ComponentList items={allComponents} showAds />
 
         <div className="screen-line-top flex justify-center p-4 before:-top-px">
           <a
@@ -247,9 +249,11 @@ export default function Page() {
 function ComponentList({
   items,
   showNew = true,
+  showAds = false,
 }: {
   items: Doc[]
   showNew?: boolean
+  showAds?: boolean
 }) {
   return (
     <div className="relative overflow-x-clip">
@@ -259,15 +263,14 @@ function ComponentList({
       </div>
 
       <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+        {showAds && CARBON_ADS && (
+          <li className="screen-line-bottom bg-background dot-grid p-2 after:z-0 empty:hidden max-md:col-span-full md:col-start-3 md:row-span-6 md:row-start-1">
+            <CarbonAds className="flex justify-center" />
+          </li>
+        )}
+
         {items.map((c) => (
-          <li
-            key={c.slug}
-            className={cn(
-              "max-sm:screen-line-bottom",
-              "sm:max-md:nth-[2n+1]:screen-line-bottom",
-              "md:nth-[3n+1]:screen-line-bottom"
-            )}
-          >
+          <li key={c.slug} className="screen-line-bottom">
             <ComponentItem href={`/components/${c.slug}` as Route}>
               <ComponentItemIcon>
                 <ComponentIcon slug={c.slug} />

--- a/src/components/carbon-ads.tsx
+++ b/src/components/carbon-ads.tsx
@@ -33,11 +33,13 @@ export function CarbonAds({
     const container = containerRef.current
     if (!CARBON_ADS || !container) return
 
-    // carbon.js inserts the ad right after its script tag, so the tag must
-    // live in this container. Route changes only need a refresh.
+    // carbon.js inserts the ad after its script tag, so the tag lives here.
+    // A loading script runs its own init, so refresh only after it loaded.
     const script = document.getElementById(SCRIPT_ID)
     if (script) {
-      if (container.contains(script)) window._carbonads?.refresh()
+      if (container.contains(script) && script.dataset.loaded) {
+        window._carbonads?.refresh()
+      }
       return
     }
 
@@ -46,6 +48,9 @@ export function CarbonAds({
     el.async = true
     el.type = "text/javascript"
     el.src = `//cdn.carbonads.com/carbon.js?serve=${CARBON_ADS.serve}&placement=${CARBON_ADS.placement}&format=${format}`
+    el.onload = () => {
+      el.dataset.loaded = "true"
+    }
     el.onerror = () => setBlocked(true)
     container.appendChild(el)
   }, [pathname, format])

--- a/src/features/blocks/components/block-list.tsx
+++ b/src/features/blocks/components/block-list.tsx
@@ -1,9 +1,33 @@
+import { CARBON_ADS } from "@/config/ads"
 import { cn } from "@/lib/utils"
+import { CarbonAds } from "@/components/carbon-ads"
 import type { Block } from "@/features/blocks/data/blocks"
 
 import { BlockItem } from "./block-item"
 
-export function BlockList({ blocks }: { blocks: Block[] }) {
+const AD_POSITION = 2
+
+const itemClassName = cn(
+  "max-sm:screen-line-top max-sm:screen-line-bottom",
+  "sm:max-lg:nth-[2n+1]:screen-line-top sm:max-lg:nth-[2n+1]:screen-line-bottom",
+  "lg:nth-[3n+1]:screen-line-top lg:nth-[3n+1]:screen-line-bottom"
+)
+
+export function BlockList({
+  blocks,
+  showAds = false,
+}: {
+  blocks: Block[]
+  showAds?: boolean
+}) {
+  const showAd = showAds && CARBON_ADS && blocks.length > 0
+
+  const renderBlock = (block: Block) => (
+    <li key={block.name} className={itemClassName}>
+      <BlockItem block={block} />
+    </li>
+  )
+
   return (
     <div className="relative py-4">
       <div className="pointer-events-none absolute inset-0 -z-1 grid grid-cols-1 gap-4 max-sm:hidden sm:grid-cols-2 lg:grid-cols-3">
@@ -13,18 +37,15 @@ export function BlockList({ blocks }: { blocks: Block[] }) {
       </div>
 
       <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {blocks.map((block) => (
-          <li
-            key={block.name}
-            className={cn(
-              "max-sm:screen-line-top max-sm:screen-line-bottom",
-              "sm:max-lg:nth-[2n+1]:screen-line-top sm:max-lg:nth-[2n+1]:screen-line-bottom",
-              "lg:nth-[3n+1]:screen-line-top lg:nth-[3n+1]:screen-line-bottom"
-            )}
-          >
-            <BlockItem block={block} />
+        {blocks.slice(0, AD_POSITION).map(renderBlock)}
+
+        {showAd && (
+          <li className={cn(itemClassName, "dot-grid empty:hidden")}>
+            <CarbonAds className="flex justify-center p-2" />
           </li>
-        ))}
+        )}
+
+        {blocks.slice(AD_POSITION).map(renderBlock)}
 
         {blocks.length === 0 && (
           <li className="screen-line-top screen-line-bottom p-4">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -180,6 +180,11 @@
   @apply bg-[repeating-linear-gradient(315deg,var(--pattern-foreground)_0,var(--pattern-foreground)_1px,transparent_0,transparent_50%)] bg-size-[10px_10px];
 }
 
+@utility dot-grid {
+  @apply [--pattern-foreground:var(--color-zinc-950)]/5 dark:[--pattern-foreground:var(--color-white)]/5;
+  @apply bg-[radial-gradient(var(--pattern-foreground)_1px,transparent_0)] bg-size-[8px_8px];
+}
+
 @utility stripe-divider {
   @apply relative h-8;
   &:before {


### PR DESCRIPTION
- components list: the unit fills the last column over the first six rows on md and a full-width row below; every item now draws its own line since the ad cell breaks the nth-child pattern
- blocks list: the unit is the third card on /blocks and /blocks/[category], skipped for empty categories
- carbon-ads: refresh only after carbon.js has loaded, a still-loading script inits itself
- add the dot-grid utility used as the ad cell background
- components page: hide the "New components" section and move the handwritten note to the left