### PR TITLE
fix: use item.title instead of item.name for metadata title in blocks…

### DIFF
--- a/src/app/(app)/(blocks)/blocks/(list)/[category]/page.tsx
+++ b/src/app/(app)/(blocks)/blocks/(list)/[category]/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({
     return {}
   }
 
-  const title = item.name
+  const title = item.title
   const description = item.description
 
   const categoryUrl = `/blocks/${item.name}`

--- a/src/app/(app)/(blocks)/blocks/(view)/[category]/[name]/page.tsx
+++ b/src/app/(app)/(blocks)/blocks/(view)/[category]/[name]/page.tsx
@@ -18,6 +18,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/base/ui/tooltip"
+import { CarbonAds } from "@/components/carbon-ads"
 import { BlockDisplay } from "@/app/(preview)/components/block-display"
 import { DocKeyboardShortcuts } from "@/features/doc/components/doc-keyboard-shortcuts"
 import { DocShareMenu } from "@/features/doc/components/doc-share-menu"
@@ -162,9 +163,11 @@ export default async function BlockViewPage({
         next={next ? (`/blocks/${next}` as Route) : null}
       />
 
+      <CarbonAds className="mb-2 flex justify-center" />
+
       <div className="screen-line-bottom flex h-px" />
 
-      <div className="flex items-center justify-between p-2 pl-4">
+      <div className="flex items-center gap-4 p-2 pl-4 max-sm:justify-between">
         <Button
           className="h-7 gap-2 border-none px-0 text-muted-foreground hover:text-foreground"
           variant="link"
@@ -179,8 +182,6 @@ export default async function BlockViewPage({
         />
 
         <div className="flex items-center gap-2">
-          <DocShareMenu title={name} url={`/blocks/${category}/${name}`} />
-
           {previous && (
             <Tooltip>
               <TooltipTrigger
@@ -239,6 +240,8 @@ export default async function BlockViewPage({
               </TooltipContent>
             </Tooltip>
           )}
+
+          <DocShareMenu title={name} url={`/blocks/${category}/${name}`} />
         </div>
       </div>
 

--- a/src/app/(app)/(docs)/blog/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/blog/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   TooltipTrigger,
 } from "@/components/base/ui/tooltip"
 import { Prose } from "@/components/base/ui/typography"
+import { CarbonAds } from "@/components/carbon-ads"
 import { MDX } from "@/components/mdx"
 import { TOCInline } from "@/components/toc-inline"
 import { TOCMinimap } from "@/components/toc-minimap"
@@ -270,6 +271,8 @@ export default async function Page({ params }: PageProps<"/blog/[slug]">) {
               <p className="text-muted-foreground">
                 {doc.metadata.description}
               </p>
+
+              <CarbonAds className="not-prose my-[1.25em] flex justify-center" />
 
               <TOCInline className="lg:hidden" items={toc} />
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -541,6 +541,10 @@
     @apply scroll-mt-18;
   }
 
+  #carbon-responsive {
+    @apply gap-2!;
+  }
+
   #carbon-responsive .carbon-poweredby {
     @apply text-muted-foreground/80! opacity-100!;
   }


### PR DESCRIPTION
… category page to display correct page title

feat: add CarbonAds component to block view and blog post pages to display advertisements

refactor: reorder navigation controls in block view footer by moving DocShareMenu after previous/next buttons to improve layout consistency

style: adjust CarbonAds spacing and add gap styling to carbon-responsive element for better visual presentation