### PR TITLE
refactor: move flex justify-center classes from CarbonAds to parent l…

### DIFF
--- a/src/app/(app)/(pages)/components/page.tsx
+++ b/src/app/(app)/(pages)/components/page.tsx
@@ -264,8 +264,8 @@ function ComponentList({
 
       <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
         {showAds && CARBON_ADS && (
-          <li className="screen-line-bottom bg-background dot-grid p-2 after:z-0 empty:hidden max-md:col-span-full md:col-start-3 md:row-span-6 md:row-start-1">
-            <CarbonAds className="flex justify-center" />
+          <li className="screen-line-bottom flex justify-center bg-background dot-grid p-2 after:z-0 empty:hidden max-md:col-span-full md:col-start-3 md:row-span-5 md:row-start-1">
+            <CarbonAds />
           </li>
         )}
 

--- a/src/features/blocks/components/block-list.tsx
+++ b/src/features/blocks/components/block-list.tsx
@@ -40,8 +40,13 @@ export function BlockList({
         {blocks.slice(0, AD_POSITION).map(renderBlock)}
 
         {showAd && (
-          <li className={cn(itemClassName, "dot-grid empty:hidden")}>
-            <CarbonAds className="flex justify-center p-2" />
+          <li
+            className={cn(
+              itemClassName,
+              "flex items-center justify-center dot-grid p-2 empty:hidden"
+            )}
+          >
+            <CarbonAds />
           </li>
         )}
 


### PR DESCRIPTION
…i elements for consistent layout control across component and block lists