### PR TITLE
feat(carbon-ads): add Carbon Ads to the registry

### DIFF
--- a/public/r/carbon-ads.json
+++ b/public/r/carbon-ads.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "carbon-ads",
+  "title": "Carbon Ads",
+  "author": "ncdai <dai@chanhdai.com>",
+  "description": "Display a Carbon Ads unit in Next.js apps, styled to match your shadcn/ui theme.",
+  "files": [
+    {
+      "path": "src/registry/components/carbon-ads/carbon-ads.tsx",
+      "content": "\"use client\"\n\nimport { useEffect, useRef, useState } from \"react\"\nimport { usePathname } from \"next/navigation\"\n\nimport { cn } from \"@/lib/utils\"\n\ndeclare global {\n  interface Window {\n    _carbonads?: {\n      refresh: () => void\n    }\n  }\n}\n\nconst SCRIPT_ID = \"_carbonads_js\"\n\nexport type CarbonAdsProps = {\n  /** The `serve` query parameter of your Carbon ad tag. */\n  serve: string\n  /** The `placement` query parameter of your Carbon ad tag. */\n  placement: string\n  /**\n   * Ad layout. `responsive` adapts to the container width, `cover` is the\n   * taller unit.\n   * @defaultValue \"responsive\"\n   */\n  format?: \"cover\" | \"responsive\"\n  className?: string\n}\n\nexport function CarbonAds({\n  serve,\n  placement,\n  format = \"responsive\",\n  className,\n}: CarbonAdsProps) {\n  const pathname = usePathname()\n  const containerRef = useRef<HTMLDivElement>(null)\n  const [blocked, setBlocked] = useState(false)\n\n  useEffect(() => {\n    const container = containerRef.current\n    if (!container) return\n\n    // carbon.js inserts the ad after its script tag, so the tag lives here.\n    // A loading script runs its own init, so refresh only after it loaded.\n    const script = document.getElementById(SCRIPT_ID)\n    if (script) {\n      if (container.contains(script) && script.dataset.loaded) {\n        window._carbonads?.refresh()\n      }\n      return\n    }\n\n    const el = document.createElement(\"script\")\n    el.id = SCRIPT_ID\n    el.async = true\n    el.type = \"text/javascript\"\n    el.src = `//cdn.carbonads.com/carbon.js?serve=${serve}&placement=${placement}&format=${format}`\n    el.onload = () => {\n      el.dataset.loaded = \"true\"\n    }\n    el.onerror = () => setBlocked(true)\n    container.appendChild(el)\n  }, [pathname, serve, placement, format])\n\n  if (blocked) return null\n\n  return (\n    <div\n      ref={containerRef}\n      data-slot=\"carbon-ads\"\n      data-format={format}\n      className={cn(\"min-h-39 data-[format=cover]:min-h-70\", className)}\n    />\n  )\n}\n",
+      "type": "registry:component",
+      "target": "@components/carbon-ads.tsx"
+    }
+  ],
+  "css": {
+    "#carbonads #carbon-responsive": {
+      "--carbon-padding": "calc(var(--spacing) * 3)",
+      "--carbon-bg-primary": "color-mix(in oklab, var(--muted) 50%, var(--background))",
+      "--carbon-bg-secondary": "var(--border)",
+      "--carbon-text-color": "var(--foreground)",
+      "@apply gap-2 font-sans": {}
+    },
+    "#carbonads #carbon-responsive .carbon-poweredby": {
+      "@apply text-xs text-muted-foreground/80 opacity-100": {}
+    }
+  },
+  "docs": "https://chanhdai.com/components/carbon-ads",
+  "categories": [
+    "utilities"
+  ],
+  "type": "registry:component"
+}

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -1079,6 +1079,36 @@
       "author": "ncdai <dai@chanhdai.com>"
     },
     {
+      "name": "carbon-ads",
+      "title": "Carbon Ads",
+      "description": "Display a Carbon Ads unit in Next.js apps, styled to match your shadcn/ui theme.",
+      "files": [
+        {
+          "path": "src/registry/components/carbon-ads/carbon-ads.tsx",
+          "type": "registry:component",
+          "target": "@components/carbon-ads.tsx"
+        }
+      ],
+      "css": {
+        "#carbonads #carbon-responsive": {
+          "--carbon-padding": "calc(var(--spacing) * 3)",
+          "--carbon-bg-primary": "color-mix(in oklab, var(--muted) 50%, var(--background))",
+          "--carbon-bg-secondary": "var(--border)",
+          "--carbon-text-color": "var(--foreground)",
+          "@apply gap-2 font-sans": {}
+        },
+        "#carbonads #carbon-responsive .carbon-poweredby": {
+          "@apply text-xs text-muted-foreground/80 opacity-100": {}
+        }
+      },
+      "docs": "https://chanhdai.com/components/carbon-ads",
+      "categories": [
+        "utilities"
+      ],
+      "type": "registry:component",
+      "author": "ncdai <dai@chanhdai.com>"
+    },
+    {
       "name": "login-01",
       "title": "Login 01",
       "description": "A simple login form.",

--- a/registry-stats.json
+++ b/registry-stats.json
@@ -1,9 +1,9 @@
 {
-  "total": 64,
+  "total": 65,
   "countByType": {
     "registry:lib": 1,
     "registry:hook": 2,
-    "registry:component": 40,
+    "registry:component": 41,
     "registry:block": 12,
     "registry:style": 9
   }

--- a/registry.json
+++ b/registry.json
@@ -1079,6 +1079,36 @@
       "author": "ncdai <dai@chanhdai.com>"
     },
     {
+      "name": "carbon-ads",
+      "title": "Carbon Ads",
+      "description": "Display a Carbon Ads unit in Next.js apps, styled to match your shadcn/ui theme.",
+      "files": [
+        {
+          "path": "src/registry/components/carbon-ads/carbon-ads.tsx",
+          "type": "registry:component",
+          "target": "@components/carbon-ads.tsx"
+        }
+      ],
+      "css": {
+        "#carbonads #carbon-responsive": {
+          "--carbon-padding": "calc(var(--spacing) * 3)",
+          "--carbon-bg-primary": "color-mix(in oklab, var(--muted) 50%, var(--background))",
+          "--carbon-bg-secondary": "var(--border)",
+          "--carbon-text-color": "var(--foreground)",
+          "@apply gap-2 font-sans": {}
+        },
+        "#carbonads #carbon-responsive .carbon-poweredby": {
+          "@apply text-xs text-muted-foreground/80 opacity-100": {}
+        }
+      },
+      "docs": "https://chanhdai.com/components/carbon-ads",
+      "categories": [
+        "utilities"
+      ],
+      "type": "registry:component",
+      "author": "ncdai <dai@chanhdai.com>"
+    },
+    {
       "name": "login-01",
       "title": "Login 01",
       "description": "A simple login form.",

--- a/src/app/(app)/(docs)/blog/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/blog/[slug]/page.tsx
@@ -272,7 +272,9 @@ export default async function Page({ params }: PageProps<"/blog/[slug]">) {
                 {doc.metadata.description}
               </p>
 
-              <CarbonAds className="not-prose my-[1.25em] flex justify-center" />
+              {doc.metadata.ads !== false && (
+                <CarbonAds className="not-prose my-[1.25em] flex justify-center" />
+              )}
 
               <TOCInline className="lg:hidden" items={toc} />
 

--- a/src/app/(app)/(docs)/components/[slug]/page.tsx
+++ b/src/app/(app)/(docs)/components/[slug]/page.tsx
@@ -286,7 +286,9 @@ export default async function Page({
         <Prose className="px-(--page-padding) pt-8 [--page-padding:--spacing(4)]">
           <p className="text-muted-foreground">{doc.metadata.description}</p>
 
-          <CarbonAds className="not-prose my-[1.25em] flex justify-center" />
+          {doc.metadata.ads !== false && (
+            <CarbonAds className="not-prose my-[1.25em] flex justify-center" />
+          )}
 
           <TOCInline className="lg:hidden" items={toc} />
 

--- a/src/components/carbon-ads.tsx
+++ b/src/components/carbon-ads.tsx
@@ -1,68 +1,15 @@
-"use client"
-
-import { useEffect, useRef, useState } from "react"
-import { usePathname } from "next/navigation"
-
 import { CARBON_ADS } from "@/config/ads"
-import { cn } from "@/lib/utils"
+import type { CarbonAdsProps } from "@/registry/transformed/components/carbon-ads"
+import { CarbonAds as CarbonAdsPrimitive } from "@/registry/transformed/components/carbon-ads"
 
-declare global {
-  interface Window {
-    _carbonads?: {
-      refresh: () => void
-    }
-  }
-}
-
-const SCRIPT_ID = "_carbonads_js"
-
-type CarbonAdsProps = {
-  className?: string
-  format?: "cover" | "responsive"
-}
-
-export function CarbonAds({
-  className,
-  format = "responsive",
-}: CarbonAdsProps) {
-  const pathname = usePathname()
-  const containerRef = useRef<HTMLDivElement>(null)
-  const [blocked, setBlocked] = useState(false)
-
-  useEffect(() => {
-    const container = containerRef.current
-    if (!CARBON_ADS || !container) return
-
-    // carbon.js inserts the ad after its script tag, so the tag lives here.
-    // A loading script runs its own init, so refresh only after it loaded.
-    const script = document.getElementById(SCRIPT_ID)
-    if (script) {
-      if (container.contains(script) && script.dataset.loaded) {
-        window._carbonads?.refresh()
-      }
-      return
-    }
-
-    const el = document.createElement("script")
-    el.id = SCRIPT_ID
-    el.async = true
-    el.type = "text/javascript"
-    el.src = `//cdn.carbonads.com/carbon.js?serve=${CARBON_ADS.serve}&placement=${CARBON_ADS.placement}&format=${format}`
-    el.onload = () => {
-      el.dataset.loaded = "true"
-    }
-    el.onerror = () => setBlocked(true)
-    container.appendChild(el)
-  }, [pathname, format])
-
-  if (!CARBON_ADS || blocked) return null
+export function CarbonAds(props: Omit<CarbonAdsProps, "serve" | "placement">) {
+  if (!CARBON_ADS) return null
 
   return (
-    <div
-      ref={containerRef}
-      data-slot="carbon-ads"
-      data-format={format}
-      className={cn("min-h-39 data-[format=cover]:min-h-70", className)}
+    <CarbonAdsPrimitive
+      serve={CARBON_ADS.serve}
+      placement={CARBON_ADS.placement}
+      {...props}
     />
   )
 }

--- a/src/features/doc/components/component-icon.tsx
+++ b/src/features/doc/components/component-icon.tsx
@@ -253,6 +253,14 @@ const COMPONENT_ICONS: Record<string, React.ReactNode> = {
       />
     </svg>
   ),
+  "carbon-ads": (
+    <svg viewBox="0 0 24 24" aria-hidden>
+      <path
+        fill="currentColor"
+        d="M8.39 16.14c0 2.71 1 3.59 4.03 3.59 1.1 0 2.91-.15 4.33-.41l.25 2.15c-1.33.33-3.28.53-4.67.53C7.81 22 6 19.96 6 16.29V7.7C6 4.04 7.8 2 12.33 2c1.4 0 3.34.2 4.67.52l-.25 2.16c-1.42-.26-3.22-.4-4.33-.4-3.03 0-4.03.87-4.03 3.58z"
+      />
+    </svg>
+  ),
 }
 
 export function ComponentIcon({ slug }: { slug: string }) {

--- a/src/features/doc/content/components/carbon-ads.mdx
+++ b/src/features/doc/content/components/carbon-ads.mdx
@@ -1,0 +1,103 @@
+---
+title: Carbon Ads
+description: Display a Carbon Ads unit in Next.js apps, styled to match your shadcn/ui theme.
+image: https://assets.chanhdai.com/images/blog/carbon-ads.webp
+ads: false
+new: true
+createdAt: 2026-09-05
+updatedAt: 2026-09-05
+---
+
+<ComponentPreview name="carbon-ads-demo" />
+
+## Features
+
+- Refreshes the ad on client-side navigation.
+- Matches your shadcn/ui theme in light and dark mode.
+- Keeps the slot height while loading and hides it when an ad blocker stops the script.
+
+## Installation
+
+<CodeTabs>
+
+<TabsListInstallType />
+
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add @ncdai/carbon-ads
+```
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Install the following dependencies</Step>
+
+```bash
+npm install cn
+```
+
+<Step>Add a cn helper</Step>
+
+<ComponentSource
+  src="src/registry/lib/utils.ts"
+  title="lib/utils.ts"
+  collapsible="false"
+/>
+
+<Step>Add the ad theme styles to your global CSS</Step>
+
+```css title="globals.css"
+#carbonads #carbon-responsive {
+  --carbon-padding: calc(var(--spacing) * 3);
+  --carbon-bg-primary: color-mix(in oklab, var(--muted) 50%, var(--background));
+  --carbon-bg-secondary: var(--border);
+  --carbon-text-color: var(--foreground);
+  @apply gap-2 font-sans;
+}
+
+#carbonads #carbon-responsive .carbon-poweredby {
+  @apply text-xs text-muted-foreground/80 opacity-100;
+}
+```
+
+<Step>Copy and paste the following code into your project</Step>
+
+<ComponentSource name="carbon-ads" title="components/carbon-ads.tsx" />
+
+<Step>Update the import paths to match your project setup</Step>
+
+</Steps>
+
+</TabsContent>
+
+</CodeTabs>
+
+## Usage
+
+```tsx
+import { CarbonAds } from "@/components/carbon-ads"
+```
+
+```tsx
+<CarbonAds serve="XXXXXXXX" placement="yoursitecom" />
+```
+
+Take `serve` and `placement` from your ad tag in the Carbon dashboard (Zones > Get Ad Tags). Carbon serves one ad per page, so render a single `CarbonAds` per route.
+
+## API reference
+
+### CarbonAds
+
+<AutoTypeTable
+  path="src/registry/components/carbon-ads/carbon-ads.tsx"
+  name="CarbonAdsProps"
+/>
+
+## References
+
+- [Carbon Ads](https://www.carbonads.net)
+- [usePathname](https://nextjs.org/docs/app/api-reference/functions/use-pathname)

--- a/src/features/doc/types/document.ts
+++ b/src/features/doc/types/document.ts
@@ -22,6 +22,10 @@ export type DocMetadata = {
    */
   pinned?: boolean
   /**
+   * Set to `false` to hide the ad unit on the doc page. Ads show by default.
+   */
+  ads?: boolean
+  /**
    * Post creation date as an ISO date string (e.g. YYYY-MM-DD). Used for sorting.
    */
   createdAt: string

--- a/src/registry/__index__.tsx
+++ b/src/registry/__index__.tsx
@@ -728,6 +728,23 @@ export const Index: Record<string, any> = {
     categories: ["controls"],
     meta: undefined,
   },
+  "carbon-ads": {
+    name: "carbon-ads",
+    description: "Display a Carbon Ads unit in Next.js apps, styled to match your shadcn/ui theme.",
+    type: "registry:component",
+    files: [{
+      path: "src/registry/components/carbon-ads/carbon-ads.tsx",
+      type: "registry:component",
+      target: "@components/carbon-ads.tsx",
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/components/carbon-ads/carbon-ads.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "carbon-ads"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: ["utilities"],
+    meta: undefined,
+  },
   "login-01": {
     name: "login-01",
     description: "A simple login form.",
@@ -1947,6 +1964,23 @@ export const Index: Record<string, any> = {
     component: React.lazy(async () => {
       const mod = await import("@/registry/examples/status-button-form-demo.tsx")
       const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "status-button-form-demo"
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "carbon-ads-demo": {
+    name: "carbon-ads-demo",
+    description: "",
+    type: "registry:example",
+    files: [{
+      path: "src/registry/examples/carbon-ads-demo.tsx",
+      type: "registry:example",
+      target: "",
+    }],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/examples/carbon-ads-demo.tsx")
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "carbon-ads-demo"
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,

--- a/src/registry/components/_registry.ts
+++ b/src/registry/components/_registry.ts
@@ -856,4 +856,33 @@ export const components: Registry["items"] = [
     categories: ["controls"],
     docs: "https://chanhdai.com/components/status-button",
   },
+  {
+    name: "carbon-ads",
+    type: "registry:component",
+    title: "Carbon Ads",
+    description:
+      "Display a Carbon Ads unit in Next.js apps, styled to match your shadcn/ui theme.",
+    files: [
+      {
+        path: "components/carbon-ads/carbon-ads.tsx",
+        type: "registry:component",
+        target: "@components/carbon-ads.tsx",
+      },
+    ],
+    css: {
+      "#carbonads #carbon-responsive": {
+        "--carbon-padding": "calc(var(--spacing) * 3)",
+        "--carbon-bg-primary":
+          "color-mix(in oklab, var(--muted) 50%, var(--background))",
+        "--carbon-bg-secondary": "var(--border)",
+        "--carbon-text-color": "var(--foreground)",
+        "@apply gap-2 font-sans": {},
+      },
+      "#carbonads #carbon-responsive .carbon-poweredby": {
+        "@apply text-xs text-muted-foreground/80 opacity-100": {},
+      },
+    },
+    categories: ["utilities"],
+    docs: "https://chanhdai.com/components/carbon-ads",
+  },
 ]

--- a/src/registry/components/carbon-ads/carbon-ads.tsx
+++ b/src/registry/components/carbon-ads/carbon-ads.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { usePathname } from "next/navigation"
+
+import { cn } from "@/lib/utils"
+
+declare global {
+  interface Window {
+    _carbonads?: {
+      refresh: () => void
+    }
+  }
+}
+
+const SCRIPT_ID = "_carbonads_js"
+
+export type CarbonAdsProps = {
+  /** The `serve` query parameter of your Carbon ad tag. */
+  serve: string
+  /** The `placement` query parameter of your Carbon ad tag. */
+  placement: string
+  /**
+   * Ad layout. `responsive` adapts to the container width, `cover` is the
+   * taller unit.
+   * @defaultValue "responsive"
+   */
+  format?: "cover" | "responsive"
+  className?: string
+}
+
+export function CarbonAds({
+  serve,
+  placement,
+  format = "responsive",
+  className,
+}: CarbonAdsProps) {
+  const pathname = usePathname()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [blocked, setBlocked] = useState(false)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    // carbon.js inserts the ad after its script tag, so the tag lives here.
+    // A loading script runs its own init, so refresh only after it loaded.
+    const script = document.getElementById(SCRIPT_ID)
+    if (script) {
+      if (container.contains(script) && script.dataset.loaded) {
+        window._carbonads?.refresh()
+      }
+      return
+    }
+
+    const el = document.createElement("script")
+    el.id = SCRIPT_ID
+    el.async = true
+    el.type = "text/javascript"
+    el.src = `//cdn.carbonads.com/carbon.js?serve=${serve}&placement=${placement}&format=${format}`
+    el.onload = () => {
+      el.dataset.loaded = "true"
+    }
+    el.onerror = () => setBlocked(true)
+    container.appendChild(el)
+  }, [pathname, serve, placement, format])
+
+  if (blocked) return null
+
+  return (
+    <div
+      ref={containerRef}
+      data-slot="carbon-ads"
+      data-format={format}
+      className={cn("min-h-39 data-[format=cover]:min-h-70", className)}
+    />
+  )
+}

--- a/src/registry/components/carbon-ads/index.ts
+++ b/src/registry/components/carbon-ads/index.ts
@@ -1,0 +1,1 @@
+export * from "./carbon-ads"

--- a/src/registry/examples/_registry.ts
+++ b/src/registry/examples/_registry.ts
@@ -653,4 +653,15 @@ export const examples: Registry["items"] = [
       },
     ],
   },
+  {
+    name: "carbon-ads-demo",
+    type: "registry:example",
+    registryDependencies: [getRegistryItemUrl("carbon-ads")],
+    files: [
+      {
+        path: "examples/carbon-ads-demo.tsx",
+        type: "registry:example",
+      },
+    ],
+  },
 ]

--- a/src/registry/examples/carbon-ads-demo.tsx
+++ b/src/registry/examples/carbon-ads-demo.tsx
@@ -1,0 +1,10 @@
+import { CarbonAds } from "@/registry/transformed/components/carbon-ads"
+
+const serve = process.env.NEXT_PUBLIC_CARBON_ADS_SERVE
+const placement = process.env.NEXT_PUBLIC_CARBON_ADS_PLACEMENT
+
+export default function CarbonAdsDemo() {
+  if (!serve || !placement) return null
+
+  return <CarbonAds serve={serve} placement={placement} />
+}

--- a/src/registry/transformed/components/carbon-ads/carbon-ads.tsx
+++ b/src/registry/transformed/components/carbon-ads/carbon-ads.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { usePathname } from "next/navigation"
+
+import { cn } from "@/lib/utils"
+
+declare global {
+  interface Window {
+    _carbonads?: {
+      refresh: () => void
+    }
+  }
+}
+
+const SCRIPT_ID = "_carbonads_js"
+
+export type CarbonAdsProps = {
+  /** The `serve` query parameter of your Carbon ad tag. */
+  serve: string
+  /** The `placement` query parameter of your Carbon ad tag. */
+  placement: string
+  /**
+   * Ad layout. `responsive` adapts to the container width, `cover` is the
+   * taller unit.
+   * @defaultValue "responsive"
+   */
+  format?: "cover" | "responsive"
+  className?: string
+}
+
+export function CarbonAds({
+  serve,
+  placement,
+  format = "responsive",
+  className,
+}: CarbonAdsProps) {
+  const pathname = usePathname()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [blocked, setBlocked] = useState(false)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    // carbon.js inserts the ad after its script tag, so the tag lives here.
+    // A loading script runs its own init, so refresh only after it loaded.
+    const script = document.getElementById(SCRIPT_ID)
+    if (script) {
+      if (container.contains(script) && script.dataset.loaded) {
+        window._carbonads?.refresh()
+      }
+      return
+    }
+
+    const el = document.createElement("script")
+    el.id = SCRIPT_ID
+    el.async = true
+    el.type = "text/javascript"
+    el.src = `//cdn.carbonads.com/carbon.js?serve=${serve}&placement=${placement}&format=${format}`
+    el.onload = () => {
+      el.dataset.loaded = "true"
+    }
+    el.onerror = () => setBlocked(true)
+    container.appendChild(el)
+  }, [pathname, serve, placement, format])
+
+  if (blocked) return null
+
+  return (
+    <div
+      ref={containerRef}
+      data-slot="carbon-ads"
+      data-format={format}
+      className={cn("min-h-39 data-[format=cover]:min-h-70", className)}
+    />
+  )
+}

--- a/src/registry/transformed/components/carbon-ads/index.ts
+++ b/src/registry/transformed/components/carbon-ads/index.ts
@@ -1,0 +1,1 @@
+export * from "./carbon-ads"


### PR DESCRIPTION
The registry component takes serve and placement as props and ships the theme CSS that maps Carbon's variables to shadcn/ui tokens. The site keeps a thin wrapper that fills the zone from env vars and renders nothing when they are unset.

Add an ads frontmatter field so a doc can hide the page-level unit. The Carbon Ads doc uses it because Carbon serves one ad per page and the demo is that ad.