### PR TITLE
feat(bookmark): add carbon ads integration to bookmark list

### DIFF
--- a/src/features/bookmark/components/bookmark-list.tsx
+++ b/src/features/bookmark/components/bookmark-list.tsx
@@ -1,13 +1,30 @@
+import { CARBON_ADS } from "@/config/ads"
+import { CarbonAds } from "@/components/carbon-ads"
+
 import type { BookmarkListEntry } from "../types"
 
+const AD_POSITION = 2
+
 export function BookmarkList({ entries }: { entries: BookmarkListEntry[] }) {
+  const showAd = CARBON_ADS && entries.length > 0
+
   return (
     <ul>
-      {entries.map((entry) => (
-        <li key={entry.url} className="border-b border-line">
-          {entry.card}
+      {entries.slice(0, AD_POSITION).map(renderEntry)}
+
+      {showAd && (
+        <li className="border-b border-line p-4 pb-2 empty:hidden">
+          <CarbonAds className="flex justify-center" />
         </li>
-      ))}
+      )}
+
+      {entries.slice(AD_POSITION).map(renderEntry)}
     </ul>
   )
 }
+
+const renderEntry = (entry: BookmarkListEntry) => (
+  <li key={entry.url} className="border-b border-line">
+    {entry.card}
+  </li>
+)


### PR DESCRIPTION
Insert carbon ad after second bookmark entry to monetize the bookmark list feature while maintaining user experience with strategic ad placement