### PR TITLE
fix(component-icon): add fill="none" attribute to swipe-actions svg t…

### DIFF
--- a/src/features/doc/components/component-icon.tsx
+++ b/src/features/doc/components/component-icon.tsx
@@ -266,6 +266,7 @@ const COMPONENT_ICONS: Record<string, React.ReactNode> = {
   "swipe-actions": (
     <svg
       viewBox="0 0 24 24"
+      fill="none"
       stroke="currentColor"
       strokeWidth="1.5"
       strokeLinecap="round"


### PR DESCRIPTION
…o prevent unwanted fill rendering